### PR TITLE
Add optional Pod Disruption Budget

### DIFF
--- a/charts/warpstream-agent/Chart.yaml
+++ b/charts/warpstream-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: warpstream-agent
 description: WarpStream Agent for Kubernetes.
 type: application
-version: 0.7.3
+version: 0.8.0
 appVersion: v518
 icon: https://avatars.githubusercontent.com/u/132156278
 home: https://docs.warpstream.com/warpstream/

--- a/charts/warpstream-agent/templates/NOTES.txt
+++ b/charts/warpstream-agent/templates/NOTES.txt
@@ -1,3 +1,9 @@
 Thank you for installing {{ .Chart.Name }}.
 
 Your release is named {{ .Release.Name }}.
+
+# CHANGELOG
+
+## 0.8.0
+
+- The default replica count has been increased from 1 to 3. You can pass `--set replicas=1` to restore the previous behavior.

--- a/charts/warpstream-agent/templates/NOTES.txt
+++ b/charts/warpstream-agent/templates/NOTES.txt
@@ -7,3 +7,4 @@ Your release is named {{ .Release.Name }}.
 ## 0.8.0
 
 - The default replica count has been increased from 1 to 3. You can pass `--set replicas=1` to restore the previous behavior.
+- Pod Disruption Budget is now supported. Pass `--set pdb.create=true` to enable it.

--- a/charts/warpstream-agent/templates/pdb.yaml
+++ b/charts/warpstream-agent/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.pdb.create }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "warpstream-agent.fullname" . }}
+  labels:
+    {{- include "warpstream-agent.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "warpstream-agent.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/warpstream-agent/values.yaml
+++ b/charts/warpstream-agent/values.yaml
@@ -8,7 +8,7 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-replicas: 1
+replicas: 3
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/charts/warpstream-agent/values.yaml
+++ b/charts/warpstream-agent/values.yaml
@@ -66,7 +66,9 @@ priorityClassName: ""
 # Optional disruption budget
 pdb:
   create: false
+  # minimum number of pods that must still be available after the eviction
   minAvailable: 1
+  # maximum number of pods that can be unavailable after the eviction
   maxUnavailable: ""
 
 ## list of hosts and IPs that will be injected into the pod's hosts file

--- a/charts/warpstream-agent/values.yaml
+++ b/charts/warpstream-agent/values.yaml
@@ -63,6 +63,12 @@ affinity: {}
 
 priorityClassName: ""
 
+# Optional disruption budget
+pdb:
+  create: false
+  minAvailable: 1
+  maxUnavailable: ""
+
 ## list of hosts and IPs that will be injected into the pod's hosts file
 hostAliases: []
   # - ip: "127.0.0.1"


### PR DESCRIPTION
It is now possible to specify a [Pod Disruption Budget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/).

    helm upgrade --install warpstream-agent warpstream/warpstream-agent \
        --reuse-values \
        --set pdb.create=true

Default replica count is now 3.
We also display a CHANGELOG.