### PR TITLE
PrometheusRule template

### DIFF
--- a/charts/warpstream-agent/CHANGELOG.md
+++ b/charts/warpstream-agent/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.10] - 2024-03-13
+
+### Added
+
+- Prometheus rule template added
+
 ## [0.10.9] - 2024-03-6
 
 ### Added

--- a/charts/warpstream-agent/Chart.yaml
+++ b/charts/warpstream-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: warpstream-agent
 description: WarpStream Agent for Kubernetes.
 type: application
-version: 0.10.9
+version: 0.10.10
 appVersion: v538
 icon: https://avatars.githubusercontent.com/u/132156278
 home: https://docs.warpstream.com/warpstream/

--- a/charts/warpstream-agent/templates/prometheus-rule.yaml
+++ b/charts/warpstream-agent/templates/prometheus-rule.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.prometheusRule.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "warpstream-agent.fullname" . }}
+  labels:
+    {{- include "warpstream-agent.labels" . | nindent 4 }}
+    {{- with .Values.prometheusRule.labels }}
+    {{- tpl (toYaml . | nindent 4) $ }}
+    {{- end }}
+spec:
+  groups:
+  {{- with .Values.prometheusRule.groups }}
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/charts/warpstream-agent/values.yaml
+++ b/charts/warpstream-agent/values.yaml
@@ -103,6 +103,24 @@ serviceMonitor:
   targetLabels: []
   honorLabels: true
 
+prometheusRule:
+  ## If true, a PrometheusRule CRD is created for a prometheus operator
+  ## https://github.com/coreos/prometheus-operator
+  ##
+  enabled: false
+  labels: {}
+  groups:
+    - name: groupName
+      rules:
+      - alert: alertName
+        expr: 'alert expression'
+        for: 5m
+        labels:
+          severity: high
+        annotations:
+          identifier: 'Alert identifier.'
+          msg: Alert message.
+
 ## list of hosts and IPs that will be injected into the pod's hosts file
 hostAliases: []
   # - ip: "127.0.0.1"


### PR DESCRIPTION
PrometheusRule template added for Prometheus alerts configuration. It is quite common in charts for example https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.9.1/charts/ingress-nginx/templates/controller-prometheusrules.yaml