### PR TITLE
Support volumes and volume mounts in the helm chart

### DIFF
--- a/charts/warpstream-agent/CHANGELOG.md
+++ b/charts/warpstream-agent/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2024-07-04
+
+### Added
+
+- Added the ability to specify arbitrary volumes and volume mounts in the pods.
+
 ## [0.12.26] - 2024-07-03
 
 ### Added

--- a/charts/warpstream-agent/Chart.yaml
+++ b/charts/warpstream-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: warpstream-agent
 description: WarpStream Agent for Kubernetes.
 type: application
-version: 0.12.26
+version: 0.13.0
 appVersion: v568
 icon: https://avatars.githubusercontent.com/u/132156278
 home: https://docs.warpstream.com/warpstream/

--- a/charts/warpstream-agent/templates/deployment.yaml
+++ b/charts/warpstream-agent/templates/deployment.yaml
@@ -100,6 +100,10 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- with .Values.initContainers }}
       initContainers:
         {{- toYaml . | nindent 8 }}
@@ -122,5 +126,9 @@ spec:
       {{- end }}
       {{- with .Values.topologySpreadConstraints }}
       topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/warpstream-agent/values.yaml
+++ b/charts/warpstream-agent/values.yaml
@@ -81,6 +81,9 @@ extraEnv: []
 # Add additional environment settings to the pod. Can be useful in proxy
 # environments
 
+volumeMounts: []
+# Add any volumeMounts to the pod.
+
 extraArgs: []
 # Add additional args settings to the pod.
 
@@ -160,6 +163,9 @@ podLabels: {}
 
 # Optional initContainers definition
 initContainers: []
+
+# Optional volume definition
+volumes: []
 
 ## Use an alternate scheduler
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/


### PR DESCRIPTION
Allows the ability to specify arbitrary volumes and volume mounts in warpstream pod. 

The use case for this is that some cloud providers (e.g. gcp) don't allow creds via environmental variables and require a service account file. A common way of implementing this is to put the service account json in a secret, then mount that secret into the pod.

There isn't really testing set up in this repo but I've installed it on gcp and it mounts the volume fine.