### PR TITLE
Allow manual override of GOMAXPROCS env var with .Values.goMaxProcs

### DIFF
--- a/charts/warpstream-agent/CHANGELOG.md
+++ b/charts/warpstream-agent/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.4] - 2024-07-17
+
+### Added
+
+- Allow manual override of GOMAXPROCS env var with .Values.goMaxProcs
+
 ## [0.13.3] - 2024-07-11
 
 ### Added

--- a/charts/warpstream-agent/Chart.yaml
+++ b/charts/warpstream-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: warpstream-agent
 description: WarpStream Agent for Kubernetes.
 type: application
-version: 0.13.3
+version: 0.13.4
 appVersion: v569
 icon: https://avatars.githubusercontent.com/u/132156278
 home: https://docs.warpstream.com/warpstream/

--- a/charts/warpstream-agent/templates/deployment.yaml
+++ b/charts/warpstream-agent/templates/deployment.yaml
@@ -81,7 +81,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "warpstream-agent.secretName" . }}
                   key: apikey
-            {{- if .Values.resources }}
+            {{- if and .Values.resources (not .Values.goMaxProcs) }}
             {{- if .Values.resources.requests }}
             {{- if not (regexMatch "^[0-9]+$" (toString .Values.resources.requests.cpu)) }}
               {{- fail "Only use whole numbers for cpu request because we are using it to set GOMAXPROCS." }}
@@ -89,6 +89,10 @@ spec:
             - name: GOMAXPROCS
               value: {{ .Values.resources.requests.cpu | quote }}
             {{- end }}
+            {{- end }}
+            {{- if .Values.goMaxProcs }}
+            - name: GOMAXPROCS
+              value: {{ .Values.goMaxProcs | quote }}
             {{- end }}
           {{- if .Values.extraEnv }}
             {{- toYaml .Values.extraEnv | nindent 12 }}

--- a/charts/warpstream-agent/values.yaml
+++ b/charts/warpstream-agent/values.yaml
@@ -77,6 +77,8 @@ resources:
   limits:
     memory: 8Gi
 
+goMaxProcs: null
+
 extraEnv: []
 # Add additional environment settings to the pod. Can be useful in proxy
 # environments


### PR DESCRIPTION
this allows setting cpu requests to non integer values (e.g. 1.95) for more efficient pod placement