### PR TITLE
optional apiKey and no replicas in playground mode

### DIFF
--- a/charts/warpstream-agent/CHANGELOG.md
+++ b/charts/warpstream-agent/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.6] - 2024-07-18
+
+### Added
+
+- Make apiKey optional and disable replicas when running agent in playground mode.
+
 ## [0.13.5] - 2024-07-17
 
 ### Added

--- a/charts/warpstream-agent/Chart.yaml
+++ b/charts/warpstream-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: warpstream-agent
 description: WarpStream Agent for Kubernetes.
 type: application
-version: 0.13.5
+version: 0.13.6
 appVersion: v570
 icon: https://avatars.githubusercontent.com/u/132156278
 home: https://docs.warpstream.com/warpstream/

--- a/charts/warpstream-agent/README.md
+++ b/charts/warpstream-agent/README.md
@@ -58,6 +58,7 @@ Bootstrap a Kubernetes cluster locally, for example with [kind][].
 helm upgrade --install warpstream-agent . --set config.playground=true
 helm test warpstream-agent
 kubectl logs warpstream-agent-diagnose-connection
+kubectl logs deployment/warpstream-agent
 ```
 
 Or manually diagnose connection with

--- a/charts/warpstream-agent/templates/deployment.yaml
+++ b/charts/warpstream-agent/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "warpstream-agent.labels" . | nindent 4 }}
 spec:
-  {{- if and (not .Values.autoscaling.enabled) (.Values.replicas) }}
+  {{- if and (not .Values.autoscaling.enabled) (.Values.replicas) (not .Values.config.playground) }}
   replicas: {{ .Values.replicas }}
   {{- end }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
@@ -76,11 +76,13 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
+            {{- if not .Values.config.playground }}
             - name: WARPSTREAM_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ include "warpstream-agent.secretName" . }}
                   key: apikey
+            {{- end }}
             {{- if and .Values.resources (not .Values.goMaxProcs) }}
             {{- if .Values.resources.requests }}
             {{- if not (regexMatch "^[0-9]+$" (toString .Values.resources.requests.cpu)) }}


### PR DESCRIPTION
Fixes `CreateContainerConfigError (secret "warpstream-agent-apikey" not found)` error when running
```
helm upgrade --install warpstream-agent . --set config.playground=true
```
as shown in the README.

Disables replicas in `playground` mode so you do not end up with multiple separate sessions.

Added additional command to README to view the agent logs so you can see the temporary developer console URL.

**Tests**
- ran locally using Rancher Desktop