### PR TITLE
Fix ServiceMonitor jobLabel, reference existing Service label

### DIFF
--- a/charts/warpstream-agent/CHANGELOG.md
+++ b/charts/warpstream-agent/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.10] - 2024-08-06
+
+### Added
+
+- Fix ServiceMonitor jobLabel, updating to an existing Service label
+
 ## [0.13.9] - 2024-08-02
 
 ### Added

--- a/charts/warpstream-agent/Chart.yaml
+++ b/charts/warpstream-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: warpstream-agent
 description: WarpStream Agent for Kubernetes.
 type: application
-version: 0.13.9
+version: 0.13.10
 appVersion: v571
 icon: https://avatars.githubusercontent.com/u/132156278
 home: https://docs.warpstream.com/warpstream/

--- a/charts/warpstream-agent/templates/servicemonitor.yaml
+++ b/charts/warpstream-agent/templates/servicemonitor.yaml
@@ -33,7 +33,7 @@ spec:
     metricRelabelings:
       {{- toYaml . | nindent 6 }}
     {{- end }}
-  jobLabel: "{{ .Release.Name }}"
+  jobLabel: app.kubernetes.io/name
   selector:
     matchLabels:
       {{- include "warpstream-agent.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
From https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.ServiceMonitorSpec;

---

`jobLabel` selects the label from the associated Kubernetes `Service` object which will be used as the job label for all metrics.

For example if `jobLabel` is set to `foo` and the Kubernetes `Service` object is labeled with `foo: bar`, then Prometheus adds the `job="bar"` label to all ingested metrics.

If the value of this field is empty or if the label doesn’t exist for the given Service, the `job` label of the metrics defaults to the name of the associated Kubernetes `Service`.

---

`{{ .Release.Name }}` will typically return "warpstream-agent" which is not the key of an existing label, so technically the lookup is always failing so the `jobLabel` is defaulting back to the name of the Service, which in most default cases is probably going to be "warpstream-agent" so it _seems_ like it is working as intended.

`app.kubernetes.io/name` looks to be a common label used for `jobLabel`, exists in the current deployment and will intentionally return "warpstream-agent".

**Other Considerations:** 
- I wasn't sure if it would make sense to move this out to `values.yaml` along with the other parameters. Happy to make that change if that is preferred.
- The [example Grafana Dashboard](https://grafana.com/grafana/dashboards/21070-warpstream-agent-overview-3/) linked on the docs page includes this selector in each of the graphs: `job=~\"($namespace)/(warpstream-agent)\"}`.  `namespace` is not currently included by default in the `job` label in the k8s deployment (either currently or with this fix) which means that someone would need to update each of those graphs before using the dashboard. Not sure what the best path forward is, just wanted to call it out.

