### PR TITLE
Make the configmap optional to allow passing env vars to the pod

### DIFF
--- a/charts/warpstream-agent/templates/configmap.yaml
+++ b/charts/warpstream-agent/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.config.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -17,3 +18,4 @@ data:
     {{- fail "region configuration value must be set" }}
   {{- end }}
   WARPSTREAM_REGION: {{ .Values.config.region | quote }}
+{{- end }}

--- a/charts/warpstream-agent/values.yaml
+++ b/charts/warpstream-agent/values.yaml
@@ -52,6 +52,7 @@ headlessService:
   enabled: true
 
 config:
+  enabled: true
   playground: false
   ## To learn what values to set for the config variables, look at our documentation
   ## for configuring the WarpStream Agents for production.


### PR DESCRIPTION
There is a need to seed the configuration data from secrets instead of a config map. This options allows us to disable the config map and pass in the conig via env vars passed into the pods that can reference secrets.