### PR TITLE
Create service per pod in a statefulset deployment

### DIFF
--- a/charts/warpstream-agent/templates/service.yaml
+++ b/charts/warpstream-agent/templates/service.yaml
@@ -34,7 +34,7 @@ spec:
   selector:
     {{- include "warpstream-agent.selectorLabels" . | nindent 4 }}
 ...
-{{- if eq (include "warpstream-agent.deploymentKind" .) "StatefulSet" }}
+{{- if and (eq (include "warpstream-agent.deploymentKind" .) "StatefulSet") (.Values.service.perPod.enabled) }}
 {{ $replicas := (.Values.replicas | int) }}
 {{- range $i, $e := until $replicas }}
 {{- with $ }}

--- a/charts/warpstream-agent/templates/service.yaml
+++ b/charts/warpstream-agent/templates/service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -32,3 +33,47 @@ spec:
     {{- end }}
   selector:
     {{- include "warpstream-agent.selectorLabels" . | nindent 4 }}
+...
+{{- if eq (include "warpstream-agent.deploymentKind" .) "StatefulSet" }}
+{{ $replicas := (.Values.replicas | int) }}
+{{- range $i, $e := until $replicas }}
+{{- with $ }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "warpstream-agent.fullname" . }}-{{ $i }}
+  labels:
+    {{- include "warpstream-agent.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    {{- if or (.Values.config.playground) (not (hasPrefix "vci_sr_" .Values.config.virtualClusterID)) }}
+    - port: {{ .Values.service.port }}
+      targetPort: kafka
+      protocol: TCP
+      name: kafka
+    {{- end }}
+    - port: {{ .Values.service.httpPort }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    {{- if or (.Values.config.playground) (hasPrefix "vci_sr_" .Values.config.virtualClusterID) }}
+    - port: {{ .Values.service.schemaRegistryPort | default 9094 }}
+      targetPort: schema-registry
+      protocol: TCP
+      name: schema-registry
+    {{- end }}
+  selector:
+    statefulset.kubernetes.io/pod-name: {{ include "warpstream-agent.fullname" . }}-{{ $i }}
+...
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/warpstream-agent/values.yaml
+++ b/charts/warpstream-agent/values.yaml
@@ -67,6 +67,8 @@ service:
   port: 9092
   httpPort: 8080
   schemaRegistryPort: 9094
+  perPod:
+    enabled: false
   labels: {}
 
 # A service that only contains the Kafka TCP port


### PR DESCRIPTION
In order to expose warpstream agents outside the cluster using host-based routing with TLS, each pod in a statefulset should have a service that the ingress object can point to for every host. This allows to expose each agent in a StatefulSet deployment with a service, allowing agent-aware load balancing instead of load balancing at the load balancer.

With a service created for every pod in a StatefulSet, we can have an ingress that routes host based traffic to specific pods.
Examples of doing it in various ingress controllers -
1. Kong
```yaml
apiVersion: configuration.konghq.com/v1beta1
kind: TCPIngress
metadata:
  name: warpstream-agent-ingress
  namespace: ws
  annotations:
    kubernetes.io/ingress.class: kong
    konghq.com/protocols: tls_passthrough
    konghq.com/snis: "ws-0.ws-headless.ws.svc.example.com, ws-1.ws-headless.ws.svc.example.com, ws-2.ws-headless.ws.svc.example.com"
spec:
  rules:
    - host: ws-0.ws-headless.ws.svc.example.com
      port: 9443
      backend:
        serviceName: ws-0
        servicePort: 9092
    - host: ws-1.ws-headless.ws.svc.example.com
      port: 9443
      backend:
        serviceName: ws-1
        servicePort: 9092
    - host: ws-2.ws-headless.ws.svc.example.com
      port: 9443
      backend:
        serviceName: ws-2
        servicePort: 9092
```
2. Istio Ingress
```yaml
apiVersion: networking.istio.io/v1
kind: VirtualService
metadata:
  name: warpstream-ingress
spec:
  hosts:
  - "ws-0.ws-headless.ws.svc.example.com"
  gateways:
  - warpstream-tls-gateway
  tcp:
  - match:
    - port: 9443
    route:
    - destination:
        host: ws-0
        port:
          number: 9092
  - "ws-1.ws-headless.ws.svc.example.com"
  gateways:
  - warpstream-tls-gateway
  tcp:
  - match:
    - port: 9443
    route:
    - destination:
        host: ws-1
        port:
          number: 9092
  - "ws-2.ws-headless.ws.svc.example.com"
  gateways:
  - warpstream-tls-gateway
  tcp:
  - match:
    - port: 9443
    route:
    - destination:
        host: ws-2
        port:
          number: 9092
```