### PR TITLE
Ability to override hostname from environment variable

### DIFF
--- a/charts/warpstream-agent/CHANGELOG.md
+++ b/charts/warpstream-agent/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.73] - 2025-01-15
+
+- Add the ability to override the advertised hostname when running a StatefulSet
+
 ## [0.13.72] - 2025-01-10
 
 - Update WarpStream Agent to v611.

--- a/charts/warpstream-agent/Chart.yaml
+++ b/charts/warpstream-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: warpstream-agent
 description: WarpStream Agent for Kubernetes.
 type: application
-version: 0.13.72
+version: 0.13.73
 appVersion: v611
 icon: https://avatars.githubusercontent.com/u/132156278
 home: https://docs.warpstream.com/warpstream/

--- a/charts/warpstream-agent/templates/_helpers.tpl
+++ b/charts/warpstream-agent/templates/_helpers.tpl
@@ -171,3 +171,14 @@ Return the Agent Key Secret Key
 apikey
 {{- end }}
 {{- end }}
+
+{{/*
+Return the agent hostname override
+*/}}
+{{- define "warpstream-agent.hostnameOverride" -}}
+{{- range $extraEnv := .Values.extraEnv }}
+{{- if eq $extraEnv.name "WARPSTREAM_DISCOVERY_KAFKA_HOSTNAME_OVERRIDE" }}
+{{- print $extraEnv.value }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/warpstream-agent/templates/deployment.yaml
+++ b/charts/warpstream-agent/templates/deployment.yaml
@@ -119,7 +119,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            {{ if eq (include "warpstream-agent.deploymentKind" .) "StatefulSet" }}
+            {{ if and (eq (include "warpstream-agent.deploymentKind" .) "StatefulSet") (not (include "warpstream-agent.hostnameOverride" .)) }}
             - name: WARPSTREAM_DISCOVERY_KAFKA_HOSTNAME_OVERRIDE
               value: $(MY_POD_NAME).{{ include "warpstream-agent.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.statefulSetConfig.clusterDomain }}
             {{ end -}}


### PR DESCRIPTION
This PR adds the ability to override the hostname of the agents when running as a statefulset. This is helpful when the cluster is exposed externally and needs a cleaner hostname. This is also necessary when the cluster domain is too long and the total characters exceed 64 for the CN in a certificate. For example, the following can be set in the values.yaml  - 
```yaml
extraEnv:
- name: WARPSTREAM_DISCOVERY_KAFKA_HOSTNAME_OVERRIDE
  value: $(MY_POD_NAME).kafka.example.com
- name: WARPSTREAM_DISCOVERY_KAFKA_PORT_OVERRIDE
  value: "9443"
```

If the environment variable `WARPSTREAM_DISCOVERY_KAFKA_HOSTNAME_OVERRIDE` is not set, the existing behaviour of setting the hostname to `$(MY_POD_NAME).{{ include "warpstream-agent.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.statefulSetConfig.clusterDomain }}` continues.


An alternative approach to implementing this would be accepting the hostname under the `statefulSetConfig` object as follows - 
```yaml
statefulSetConfig:
  hostnameOverride: $(MY_POD_NAME).kafka.example.com
```
Please let me know if you prefer this approach. I can open a new PR with this.