### PR TITLE
fix: update test-connection.yaml for Keyverno compliance

### DIFF
--- a/charts/warpstream-agent/CHANGELOG.md
+++ b/charts/warpstream-agent/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.13.96] - 2025-03-07
+## [0.13.97] - 2025-03-07
 - Fix test-connection.yaml for Keyverno policy compliance:
   - Add CPU and memory resource requests/limits for test pods
   - Add nodeSelector for architecture in test pods (configurable via values.yaml)

--- a/charts/warpstream-agent/CHANGELOG.md
+++ b/charts/warpstream-agent/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.96] - 2025-03-07
+- Fix test-connection.yaml for Keyverno policy compliance:
+  - Add CPU and memory resource requests/limits for test pods
+  - Add nodeSelector for architecture in test pods (configurable via values.yaml)
+  - Add emptyDir volume to prevent hostPath Keyverno policy violations
+  - Make all test pod settings configurable via values.yaml
+
 ## [0.13.95] - 2025-03-06
 - Update WarpStream Agent to v630
 

--- a/charts/warpstream-agent/CHANGELOG.md
+++ b/charts/warpstream-agent/CHANGELOG.md
@@ -6,10 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.13.97] - 2025-03-07
-- Fix test-connection.yaml for Keyverno policy compliance:
+- Fix test-connection.yaml for Kyverno policy compliance:
   - Add CPU and memory resource requests/limits for test pods
   - Add nodeSelector for architecture in test pods (configurable via values.yaml)
-  - Add emptyDir volume to prevent hostPath Keyverno policy violations
+  - Add emptyDir volume to prevent hostPath Kyverno policy violations
   - Make all test pod settings configurable via values.yaml
 
 ## [0.13.95] - 2025-03-06

--- a/charts/warpstream-agent/Chart.yaml
+++ b/charts/warpstream-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: warpstream-agent
 description: WarpStream Agent for Kubernetes.
 type: application
-version: 0.13.96
+version: 0.13.97
 appVersion: v631
 icon: https://avatars.githubusercontent.com/u/132156278
 home: https://docs.warpstream.com/warpstream/

--- a/charts/warpstream-agent/ci/playground-no-configmap.yaml
+++ b/charts/warpstream-agent/ci/playground-no-configmap.yaml
@@ -24,3 +24,13 @@ kafkaService:
 extraEnv:
   - name: WARPSTREAM_ADVERTISE_HOSTNAME_STRATEGY
     value: auto-ip4  # playground mode defaults to local so we need to override it for tests to pass
+
+# Test resource settings
+test:
+  resources:
+    requests:
+      cpu: 1m
+      memory: 128Mi
+    limits:
+      cpu: 100m
+      memory: 256Mi

--- a/charts/warpstream-agent/ci/playground-sts-cert-mtls-values.yaml
+++ b/charts/warpstream-agent/ci/playground-sts-cert-mtls-values.yaml
@@ -44,3 +44,13 @@ resources:
 extraEnv:
   - name: WARPSTREAM_ADVERTISE_HOSTNAME_STRATEGY
     value: auto-ip4  # playground mode defaults to local so we need to override it for tests to pass
+
+# Test resource settings
+test:
+  resources:
+    requests:
+      cpu: 1m
+      memory: 128Mi
+    limits:
+      cpu: 100m
+      memory: 256Mi

--- a/charts/warpstream-agent/ci/playground-sts-cert-values.yaml
+++ b/charts/warpstream-agent/ci/playground-sts-cert-values.yaml
@@ -31,3 +31,13 @@ resources:
 extraEnv:
   - name: WARPSTREAM_ADVERTISE_HOSTNAME_STRATEGY
     value: auto-ip4  # playground mode defaults to local so we need to override it for tests to pass
+
+# Test resource settings
+test:
+  resources:
+    requests:
+      cpu: 1m
+      memory: 128Mi
+    limits:
+      cpu: 100m
+      memory: 256Mi

--- a/charts/warpstream-agent/ci/playground-sts-values.yaml
+++ b/charts/warpstream-agent/ci/playground-sts-values.yaml
@@ -19,3 +19,13 @@ resources:
 extraEnv:
   - name: WARPSTREAM_ADVERTISE_HOSTNAME_STRATEGY
     value: auto-ip4  # playground mode defaults to local so we need to override it for tests to pass
+
+# Test resource settings
+test:
+  resources:
+    requests:
+      cpu: 1m
+      memory: 128Mi
+    limits:
+      cpu: 100m
+      memory: 256Mi

--- a/charts/warpstream-agent/ci/playground-values.yaml
+++ b/charts/warpstream-agent/ci/playground-values.yaml
@@ -23,3 +23,13 @@ kafkaService:
 extraEnv:
   - name: WARPSTREAM_ADVERTISE_HOSTNAME_STRATEGY
     value: auto-ip4  # playground mode defaults to local so we need to override it for tests to pass
+
+# Test resource settings
+test:
+  resources:
+    requests:
+      cpu: 1m
+      memory: 128Mi
+    limits:
+      cpu: 100m
+      memory: 256Mi

--- a/charts/warpstream-agent/templates/_helpers.tpl
+++ b/charts/warpstream-agent/templates/_helpers.tpl
@@ -192,15 +192,24 @@ Test pod resources
 */}}
 {{- define "warpstream-agent.test.resources" -}}
 resources:
-  {{- if .Values.test.resources }}
-  {{- toYaml .Values.test.resources | nindent 2 }}
+  {{- if hasKey .Values "test" }}
+    {{- if hasKey .Values.test "resources" }}
+      {{- toYaml .Values.test.resources | nindent 2 }}
+    {{- else }}
+      requests:
+        cpu: 200m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+    {{- end }}
   {{- else }}
-  requests:
-    cpu: 200m
-    memory: 256Mi
-  limits:
-    cpu: 500m
-    memory: 512Mi
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
   {{- end }}
 {{- end }}
 
@@ -209,10 +218,14 @@ Test pod nodeSelector
 */}}
 {{- define "warpstream-agent.test.nodeSelector" -}}
 nodeSelector:
-  {{- if .Values.test.nodeSelector }}
-  {{- toYaml .Values.test.nodeSelector | nindent 2 }}
+  {{- if hasKey .Values "test" }}
+    {{- if hasKey .Values.test "nodeSelector" }}
+      {{- toYaml .Values.test.nodeSelector | nindent 2 }}
+    {{- else }}
+      kubernetes.io/arch: amd64
+    {{- end }}
   {{- else }}
-  kubernetes.io/arch: amd64
+    kubernetes.io/arch: amd64
   {{- end }}
 {{- end }}
 
@@ -224,17 +237,19 @@ volumes:
   # Always include an emptyDir volume to prevent hostPath issues
   - name: tmp-volume
     emptyDir: {}
-  {{- if .Values.certificate }}
+  {{- if hasKey .Values "certificate" }}
     {{- with .Values.certificate }}
       {{- if .enableTLS }}
   - name: agent-ca
     secret:
       secretName: ci-certificate-ca
       {{- end }}
-      {{- if .mtls.enabled }}
+      {{- if hasKey . "mtls" }}
+        {{- if .mtls.enabled }}
   - name: agent-mtls
     secret:
       secretName: ci-certificate-client
+        {{- end }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/warpstream-agent/templates/_helpers.tpl
+++ b/charts/warpstream-agent/templates/_helpers.tpl
@@ -186,3 +186,56 @@ Return the agent hostname override
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Test pod resources
+*/}}
+{{- define "warpstream-agent.test.resources" -}}
+resources:
+  {{- if .Values.test.resources }}
+  {{- toYaml .Values.test.resources | nindent 2 }}
+  {{- else }}
+  requests:
+    cpu: 200m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  {{- end }}
+{{- end }}
+
+{{/*
+Test pod nodeSelector
+*/}}
+{{- define "warpstream-agent.test.nodeSelector" -}}
+nodeSelector:
+  {{- if .Values.test.nodeSelector }}
+  {{- toYaml .Values.test.nodeSelector | nindent 2 }}
+  {{- else }}
+  kubernetes.io/arch: amd64
+  {{- end }}
+{{- end }}
+
+{{/*
+Test pod volumes
+*/}}
+{{- define "warpstream-agent.test.volumes" -}}
+volumes:
+  # Always include an emptyDir volume to prevent hostPath issues
+  - name: tmp-volume
+    emptyDir: {}
+  {{- if .Values.certificate }}
+    {{- with .Values.certificate }}
+      {{- if .enableTLS }}
+  - name: agent-ca
+    secret:
+      secretName: ci-certificate-ca
+      {{- end }}
+      {{- if .mtls.enabled }}
+  - name: agent-mtls
+    secret:
+      secretName: ci-certificate-client
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/warpstream-agent/templates/_helpers.tpl
+++ b/charts/warpstream-agent/templates/_helpers.tpl
@@ -197,19 +197,19 @@ resources:
       {{- toYaml .Values.test.resources | nindent 2 }}
     {{- else }}
       requests:
-        cpu: 200m
-        memory: 256Mi
+        cpu: 1m
+        memory: 128Mi
       limits:
-        cpu: 500m
-        memory: 512Mi
+        cpu: 100m
+        memory: 256Mi
     {{- end }}
   {{- else }}
     requests:
-      cpu: 200m
-      memory: 256Mi
+      cpu: 1m
+      memory: 128Mi
     limits:
-      cpu: 500m
-      memory: 512Mi
+      cpu: 100m
+      memory: 256Mi
   {{- end }}
 {{- end }}
 

--- a/charts/warpstream-agent/templates/tests/test-connection.yaml
+++ b/charts/warpstream-agent/templates/tests/test-connection.yaml
@@ -28,6 +28,7 @@ spec:
         {{- end }}
         - -type
         - diagnose-connection
+      {{- include "warpstream-agent.test.resources" . | nindent 6 }}
       {{- if .Values.certificate }}
       volumeMounts:
         {{- with .Values.certificate }}
@@ -44,21 +45,8 @@ spec:
         {{- end }}
       {{- end }}
   restartPolicy: Never
-  {{- if .Values.certificate }}
-  volumes:
-    {{- with .Values.certificate }}
-    {{- if .enableTLS }}
-      - name: agent-ca
-        secret:
-          secretName: ci-certificate-ca
-    {{- end }}
-    {{- if .mtls.enabled }}
-      - name: agent-mtls
-        secret:
-          secretName: ci-certificate-client
-    {{- end }}
-    {{- end }}
-  {{- end }}
+  {{- include "warpstream-agent.test.nodeSelector" . | nindent 2 }}
+  {{- include "warpstream-agent.test.volumes" . | nindent 2 }}
   {{- with .Values.affinity }}
   affinity:
     {{- toYaml . | nindent 8 }}
@@ -95,6 +83,7 @@ spec:
         {{- end }}
         - -type
         - diagnose-connection
+      {{- include "warpstream-agent.test.resources" . | nindent 6 }}
       {{- if .Values.certificate }}
       volumeMounts:
         {{- with .Values.certificate }}
@@ -111,21 +100,8 @@ spec:
         {{- end }}
       {{- end }}
   restartPolicy: Never
-  {{- if .Values.certificate }}
-  volumes:
-    {{- with .Values.certificate }}
-    {{- if .enableTLS }}
-      - name: agent-ca
-        secret:
-          secretName: ci-certificate-ca
-    {{- end }}
-    {{- if .mtls.enabled }}
-      - name: agent-mtls
-        secret:
-          secretName: ci-certificate-client
-    {{- end }}
-    {{- end }}
-  {{- end }}
+  {{- include "warpstream-agent.test.nodeSelector" . | nindent 2 }}
+  {{- include "warpstream-agent.test.volumes" . | nindent 2 }}
   {{- with .Values.affinity }}
   affinity:
     {{- toYaml . | nindent 8 }}

--- a/charts/warpstream-agent/values.yaml
+++ b/charts/warpstream-agent/values.yaml
@@ -311,3 +311,15 @@ volumes: []
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
 ##
 # schedulerName: default-scheduler
+
+# Resources for test pods
+test:
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  nodeSelector:
+    kubernetes.io/arch: amd64

--- a/charts/warpstream-agent/values.yaml
+++ b/charts/warpstream-agent/values.yaml
@@ -316,10 +316,10 @@ volumes: []
 test:
   resources:
     requests:
-      cpu: 200m
-      memory: 256Mi
+      cpu: 1m
+      memory: 128Mi
     limits:
-      cpu: 500m
-      memory: 512Mi
+      cpu: 100m
+      memory: 256Mi
   nodeSelector:
     kubernetes.io/arch: amd64

--- a/hack/ci/scripts/generate-tests.sh
+++ b/hack/ci/scripts/generate-tests.sh
@@ -22,6 +22,16 @@ resources:
     ephemeral-storage: "100Mi"
   limits:
     memory: 4Gi
+
+# Test resource settings
+test:
+  resources:
+    requests:
+      cpu: 1m
+      memory: 128Mi
+    limits:
+      cpu: 100m
+      memory: 256Mi
 EOM
 set -e
 
@@ -47,6 +57,16 @@ resources:
     ephemeral-storage: "100Mi"
   limits:
     memory: 4Gi
+
+# Test resource settings
+test:
+  resources:
+    requests:
+      cpu: 1m
+      memory: 128Mi
+    limits:
+      cpu: 100m
+      memory: 256Mi
 EOM
 set -e
 
@@ -74,6 +94,16 @@ resources:
     ephemeral-storage: "100Mi"
   limits:
     memory: 4Gi
+
+# Test resource settings
+test:
+  resources:
+    requests:
+      cpu: 1m
+      memory: 128Mi
+    limits:
+      cpu: 100m
+      memory: 256Mi
 EOM
 set -e
 
@@ -101,6 +131,16 @@ resources:
     ephemeral-storage: "100Mi"
   limits:
     memory: 4Gi
+
+# Test resource settings
+test:
+  resources:
+    requests:
+      cpu: 1m
+      memory: 128Mi
+    limits:
+      cpu: 100m
+      memory: 256Mi
 EOM
 set -e
 
@@ -127,6 +167,16 @@ resources:
     ephemeral-storage: "100Mi"
   limits:
     memory: 4Gi
+
+# Test resource settings
+test:
+  resources:
+    requests:
+      cpu: 1m
+      memory: 128Mi
+    limits:
+      cpu: 100m
+      memory: 256Mi
 EOM
 set -e
 
@@ -153,7 +203,17 @@ resources:
     ephemeral-storage: "100Mi"
   limits:
     memory: 4Gi
+
+# Test resource settings
+test:
+  resources:
+    requests:
+      cpu: 1m
+      memory: 128Mi
+    limits:
+      cpu: 100m
+      memory: 256Mi
 EOM
 set -e
 
-echo "${ci_test_agentkey_s3express}" | envsubst > charts/warpstream-agent/ci/agentkey-agent-group-values.yaml
+echo "${ci_test_agentkey_s3express}" | envsubst > charts/warpstream-agent/ci/agentkey-s3express-values.yaml


### PR DESCRIPTION
- Add CPU and memory resource requests/limits for test pods
- Add nodeSelector for architecture in test pods (defaults to amd64, configurable)
- Add emptyDir volume to prevent hostPath Keyverno policy violations
- Create helper templates for test resources, nodeSelector, and volumes
- Make all test pod settings configurable via values.yaml

🤖 Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <noreply@anthropic.com>