### PR TITLE
Add namespace for "helm template" usage

### DIFF
--- a/charts/warpstream-agent/CHANGELOG.md
+++ b/charts/warpstream-agent/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.16] - 2025-06-19
+- Added namespace to templates for proper "helm template" processing.
+
 ## [0.15.15] - 2025-06-18
 - Update WarpStream Agent to v666
 

--- a/charts/warpstream-agent/Chart.yaml
+++ b/charts/warpstream-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: warpstream-agent
 description: WarpStream Agent for Kubernetes.
 type: application
-version: 0.15.15
+version: 0.15.16
 appVersion: v666
 icon: https://avatars.githubusercontent.com/u/132156278
 home: https://docs.warpstream.com/warpstream/

--- a/charts/warpstream-agent/templates/configmap.yaml
+++ b/charts/warpstream-agent/templates/configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "warpstream-agent.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "warpstream-agent.labels" . | nindent 4 }}
   {{- with .Values.annotations }}

--- a/charts/warpstream-agent/templates/deployment.yaml
+++ b/charts/warpstream-agent/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: {{ include "warpstream-agent.deploymentKind" . }}
 metadata:
   name: {{ include "warpstream-agent.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "warpstream-agent.labels" . | nindent 4 }}
   {{- with .Values.annotations }}

--- a/charts/warpstream-agent/templates/hpa.yaml
+++ b/charts/warpstream-agent/templates/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "warpstream-agent.hpa.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "warpstream-agent.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{ include "warpstream-agent.labels" . | nindent 4 }}
   {{- with .Values.annotations }}
   annotations:

--- a/charts/warpstream-agent/templates/networkpolicy.yaml
+++ b/charts/warpstream-agent/templates/networkpolicy.yaml
@@ -4,6 +4,7 @@ kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: {{ include "warpstream-agent.fullname" . }}-networkpolicy
+  namespace: {{ .Release.Namespace }}
   labels: {{ include "warpstream-agent.labels" . | nindent 4 }}
   {{- with .Values.annotations }}
   annotations:

--- a/charts/warpstream-agent/templates/pdb.yaml
+++ b/charts/warpstream-agent/templates/pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "warpstream-agent.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "warpstream-agent.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "warpstream-agent.labels" . | nindent 4 }}
   {{- with .Values.annotations }}

--- a/charts/warpstream-agent/templates/prometheus-rule.yaml
+++ b/charts/warpstream-agent/templates/prometheus-rule.yaml
@@ -4,6 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ include "warpstream-agent.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "warpstream-agent.labels" . | nindent 4 }}
     {{- with .Values.prometheusRule.labels }}

--- a/charts/warpstream-agent/templates/role.yaml
+++ b/charts/warpstream-agent/templates/role.yaml
@@ -9,6 +9,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   name: {{ include "warpstream-agent.fullname" . }}-role
+  namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups:
   - ""

--- a/charts/warpstream-agent/templates/rolebinding.yaml
+++ b/charts/warpstream-agent/templates/rolebinding.yaml
@@ -3,6 +3,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "warpstream-agent.fullname" . }}-rolebinding
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "warpstream-agent.labels" . | nindent 4 }}
   {{- with .Values.annotations }}

--- a/charts/warpstream-agent/templates/scrapeconfig.yaml
+++ b/charts/warpstream-agent/templates/scrapeconfig.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "warpstream-agent.secretName" . }}-hostedprometheus
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "warpstream-agent.labels" . | nindent 4 }}
   {{- with .Values.annotations }}
@@ -18,6 +19,7 @@ apiVersion: monitoring.coreos.com/v1alpha1
 kind: ScrapeConfig
 metadata:
   name: {{ include "warpstream-agent.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "warpstream-agent.labels" . | nindent 4 }}
     {{- with .Values.scrapeConfig.labels }}

--- a/charts/warpstream-agent/templates/secret-agent-key.yaml
+++ b/charts/warpstream-agent/templates/secret-agent-key.yaml
@@ -12,6 +12,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "warpstream-agent.secretName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "warpstream-agent.labels" . | nindent 4 }}
   {{- with .Values.annotations }}

--- a/charts/warpstream-agent/templates/secret-deprecated-api-key.yaml
+++ b/charts/warpstream-agent/templates/secret-deprecated-api-key.yaml
@@ -12,6 +12,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "warpstream-agent.secretName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "warpstream-agent.labels" . | nindent 4 }}
   {{- with .Values.annotations }}

--- a/charts/warpstream-agent/templates/service-headless.yaml
+++ b/charts/warpstream-agent/templates/service-headless.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "warpstream-agent.fullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "warpstream-agent.labels" . | nindent 4 }}
   {{- with (mergeOverwrite (default (dict) .Values.annotations) (default (dict) .Values.headlessService.annotations)) }}

--- a/charts/warpstream-agent/templates/service-kafka.yaml
+++ b/charts/warpstream-agent/templates/service-kafka.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "warpstream-agent.fullname" . }}-kafka
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "warpstream-agent.labels" . | nindent 4 }}
   {{- with (mergeOverwrite (default (dict) .Values.annotations) (default (dict) .Values.kafkaService.annotations)) }}

--- a/charts/warpstream-agent/templates/service.yaml
+++ b/charts/warpstream-agent/templates/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "warpstream-agent.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "warpstream-agent.labels" . | nindent 4 }}
     {{- with .Values.service.labels }}

--- a/charts/warpstream-agent/templates/serviceaccount.yaml
+++ b/charts/warpstream-agent/templates/serviceaccount.yaml
@@ -4,6 +4,7 @@ kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "warpstream-agent.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "warpstream-agent.labels" . | nindent 4 }}
   {{- with (mergeOverwrite (default (dict) .Values.annotations) (default (dict) .Values.serviceAccount.annotations)) }}

--- a/charts/warpstream-agent/templates/servicemonitor.yaml
+++ b/charts/warpstream-agent/templates/servicemonitor.yaml
@@ -4,6 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "warpstream-agent.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "warpstream-agent.labels" . | nindent 4 }}
     {{- with .Values.serviceMonitor.labels }}

--- a/charts/warpstream-agent/templates/tests/test-connection.yaml
+++ b/charts/warpstream-agent/templates/tests/test-connection.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "warpstream-agent.fullname" . }}-diagnose-connection"
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "warpstream-agent.labels" . | nindent 4 }}
   annotations:

--- a/charts/warpstream-benchmark/Chart.yaml
+++ b/charts/warpstream-benchmark/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: warpstream-benchmark
 description: WarpStream Benchmark for Kubernetes.
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: v652
 icon: https://avatars.githubusercontent.com/u/132156278
 home: https://docs.warpstream.com/warpstream/

--- a/charts/warpstream-benchmark/templates/consumer_deployment.yaml
+++ b/charts/warpstream-benchmark/templates/consumer_deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "warpstream-benchmark.fullname" . }}-consumer
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "warpstream-benchmark.labels" . | nindent 4 }}
 spec:

--- a/charts/warpstream-benchmark/templates/consumer_service.yaml
+++ b/charts/warpstream-benchmark/templates/consumer_service.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "warpstream-benchmark.fullname" . }}-consumer
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "warpstream-benchmark.labels" . | nindent 4 }}
     {{- with .Values.service.labels }}

--- a/charts/warpstream-benchmark/templates/consumer_servicemonitor.yaml
+++ b/charts/warpstream-benchmark/templates/consumer_servicemonitor.yaml
@@ -5,6 +5,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "warpstream-benchmark.fullname" . }}-consumer
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "warpstream-benchmark.labels" . | nindent 4 }}
     {{- with .Values.serviceMonitor.labels }}

--- a/charts/warpstream-benchmark/templates/producer_deployment.yaml
+++ b/charts/warpstream-benchmark/templates/producer_deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "warpstream-benchmark.fullname" . }}-producer
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "warpstream-benchmark.labels" . | nindent 4 }}
 spec:

--- a/charts/warpstream-benchmark/templates/producer_service.yaml
+++ b/charts/warpstream-benchmark/templates/producer_service.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "warpstream-benchmark.fullname" . }}-producer
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "warpstream-benchmark.labels" . | nindent 4 }}
     {{- with .Values.service.labels }}

--- a/charts/warpstream-benchmark/templates/producer_servicemonitor.yaml
+++ b/charts/warpstream-benchmark/templates/producer_servicemonitor.yaml
@@ -5,6 +5,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "warpstream-benchmark.fullname" . }}-producer
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "warpstream-benchmark.labels" . | nindent 4 }}
     {{- with .Values.serviceMonitor.labels }}


### PR DESCRIPTION
Tools that use "helm template", like ArgoCD or our custom Kontemplate, need resource namespace properly populated from the template.  Per https://github.com/helm/helm/issues/3553, that's the template's responsibility.