### PR TITLE
helm template APIVersions lacks Resource

### DIFF
--- a/charts/warpstream-agent/CHANGELOG.md
+++ b/charts/warpstream-agent/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.15] - 2025-06-18
+- Update WarpStream Agent to v666
+
 ## [0.15.14] - 2025-06-17
 - Update WarpStream Agent to v665
 

--- a/charts/warpstream-agent/CHANGELOG.md
+++ b/charts/warpstream-agent/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.14] - 2025-06-17
+- Update WarpStream Agent to v665
+
 ## [0.15.13] - 2025-06-16
 - Update WarpStream Agent to v664
 

--- a/charts/warpstream-agent/CHANGELOG.md
+++ b/charts/warpstream-agent/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.22] - 2025-06-30
+- "helm template" APIVersions lacks Resource
+
 ## [0.15.15] - 2025-06-18
 - Update WarpStream Agent to v666
 

--- a/charts/warpstream-agent/Chart.yaml
+++ b/charts/warpstream-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: warpstream-agent
 description: WarpStream Agent for Kubernetes.
 type: application
-version: 0.15.14
-appVersion: v665
+version: 0.15.15
+appVersion: v666
 icon: https://avatars.githubusercontent.com/u/132156278
 home: https://docs.warpstream.com/warpstream/
 sources:

--- a/charts/warpstream-agent/Chart.yaml
+++ b/charts/warpstream-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: warpstream-agent
 description: WarpStream Agent for Kubernetes.
 type: application
-version: 0.15.13
-appVersion: v664
+version: 0.15.14
+appVersion: v665
 icon: https://avatars.githubusercontent.com/u/132156278
 home: https://docs.warpstream.com/warpstream/
 sources:

--- a/charts/warpstream-agent/Chart.yaml
+++ b/charts/warpstream-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: warpstream-agent
 description: WarpStream Agent for Kubernetes.
 type: application
-version: 0.15.15
-appVersion: v666
+version: 0.15.22
+appVersion: v669
 icon: https://avatars.githubusercontent.com/u/132156278
 home: https://docs.warpstream.com/warpstream/
 sources:

--- a/charts/warpstream-agent/templates/_helpers.tpl
+++ b/charts/warpstream-agent/templates/_helpers.tpl
@@ -78,7 +78,11 @@ Return the appropriate apiVersion for Horizontal Pod Autoscaler.
 {{- define "warpstream-agent.hpa.apiVersion" -}}
 {{- if $.Capabilities.APIVersions.Has "autoscaling/v2/HorizontalPodAutoscaler" }}
 {{- print "autoscaling/v2" }}
+{{- else if $.Capabilities.APIVersions.Has "autoscaling/v2" }}
+{{- print "autoscaling/v2" }}
 {{- else if $.Capabilities.APIVersions.Has "autoscaling/v2beta2/HorizontalPodAutoscaler" }}
+{{- print "autoscaling/v2beta2" }}
+{{- else if $.Capabilities.APIVersions.Has "autoscaling/v2beta2" }}
 {{- print "autoscaling/v2beta2" }}
 {{- else }}
 {{- print "autoscaling/v2beta1" }}
@@ -92,6 +96,8 @@ Return the appropriate apiVersion for podDisruptionBudget.
 {{- if $.Values.pdb.apiVersion }}
 {{- print $.Values.pdb.apiVersion }}
 {{- else if $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
+{{- print "policy/v1" }}
+{{- else if $.Capabilities.APIVersions.Has "policy/v1" }}
 {{- print "policy/v1" }}
 {{- else }}
 {{- print "policy/v1beta1" }}

--- a/charts/warpstream-agent/values.yaml
+++ b/charts/warpstream-agent/values.yaml
@@ -17,7 +17,7 @@ replicas: 3
 # URL in your Kafka clients, and switch to the Kubernetes service name instead. The reason for this is that
 # when you switch to StatefulSet, the Agents will begin advertising their stable pod names in the Kafka
 # protocol as their hostname, instead of their internal IP addresses. When this happens, WarpStream's DNS
-# server will start returning CNAME's for the convience bootstrap URL for each Agent. Since these CNAME's
+# server will start returning CNAME's for the convenience bootstrap URL for each Agent. Since these CNAME's
 # are private to the Kubernetes cluster WarpStream's DNS server cannot resolve them causing applications
 # to fail to connect.
 #


### PR DESCRIPTION
When using "helm template", it populates the .Capabilities.APIVersions object from the compiled in kubernetes go client code.  As a result, they APIs list does not have versions ending with the Resource.  This changes the helper to work in the "helm template" environment as well as the "helm install/upgrade" environment.