### PR TITLE
Avoid gomaxprocs math when goprocsmax is explicitly declared

### DIFF
--- a/charts/warpstream-agent/CHANGELOG.md
+++ b/charts/warpstream-agent/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.24] - 2025-07-03
+- skip gomaxprocs math if gomaxprocs is explicitly set
+
 ## [0.15.23] - 2025-06-30
 - Update WarpStream Agent to v670
 

--- a/charts/warpstream-agent/Chart.yaml
+++ b/charts/warpstream-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: warpstream-agent
 description: WarpStream Agent for Kubernetes.
 type: application
-version: 0.15.23
+version: 0.15.24
 appVersion: v670
 icon: https://avatars.githubusercontent.com/u/132156278
 home: https://docs.warpstream.com/warpstream/

--- a/charts/warpstream-agent/templates/deployment.yaml
+++ b/charts/warpstream-agent/templates/deployment.yaml
@@ -119,9 +119,13 @@ spec:
             failureThreshold: 5
             periodSeconds: 5
           resources:
+            {{- $goMaxProcs := 0 -}}
+            {{- if .Values.goMaxProcs -}}
+            {{- $goMaxProcs = .Values.goMaxProcs -}}
+            {{- else -}}
             {{- $cpuMillicoresRequest := .Values.resources.requests.cpu | include "convertToMillicores" -}}
-            {{- $goMaxProcs := divf $cpuMillicoresRequest 1000 -}}
-            {{- $goMaxProcs := ceil $goMaxProcs -}}
+            {{- $goMaxProcs = divf $cpuMillicoresRequest 1000 -}}
+            {{- $goMaxProcs = ceil $goMaxProcs -}}
             {{- if .Values.enforceProductionResourceRequirements}}
             {{- $memoryRequest := .Values.resources.requests.memory | include "convertToBytes" -}}
             {{- $memoryPerMillicore := divf $memoryRequest $cpuMillicoresRequest -}}
@@ -129,6 +133,7 @@ spec:
             {{- $minMemoryPerCPU := 4000000000.0 -}}
             {{- if lt $memoryPerCPU $minMemoryPerCPU -}}
             {{ fail (printf "Memory request per CPU (%.2f GiB) is less than the required 4 GiB per CPU. Please increase the memory request." (divf $memoryPerCPU 1073741824)) }}
+            {{- end -}}
             {{- end -}}
             {{- end -}}
             {{- toYaml .Values.resources | nindent 12 }}
@@ -151,15 +156,9 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
-            {{- if and .Values.resources (not .Values.goMaxProcs) }}
-            {{- if .Values.resources.requests }}
+            {{- if or .Values.resources.requests .Values.goMaxProcs }}
             - name: GOMAXPROCS
               value: {{ $goMaxProcs | quote }}
-            {{- end }}
-            {{- end }}
-            {{- if .Values.goMaxProcs }}
-            - name: GOMAXPROCS
-              value: {{ .Values.goMaxProcs | quote }}
             {{- end }}
           {{- if .Values.extraEnv }}
             {{- toYaml .Values.extraEnv | nindent 12 }}


### PR DESCRIPTION
We pass templating strings rather than numbers through the resources cpu/mem and explicitly set gomaxcpus.  As a result, we do not want the template to try to do math on a text string.  This change makes the chart skip gomaxcpus calculation if it is already explicitly set.