### PR TITLE
Add support for sidecar containers

### DIFF
--- a/charts/warpstream-agent/CHANGELOG.md
+++ b/charts/warpstream-agent/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.62] - 2025-09-26
+- Add Values.sidecarContainers to configure additional containers in the pod
+
 ## [0.15.61] - 2025-09-24
 - Update WarpStream Agent to v706
 

--- a/charts/warpstream-agent/Chart.yaml
+++ b/charts/warpstream-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: warpstream-agent
 description: WarpStream Agent for Kubernetes.
 type: application
-version: 0.15.61
+version: 0.15.62
 appVersion: v706
 icon: https://avatars.githubusercontent.com/u/132156278
 home: https://docs.warpstream.com/warpstream/

--- a/charts/warpstream-agent/templates/deployment.yaml
+++ b/charts/warpstream-agent/templates/deployment.yaml
@@ -206,6 +206,9 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
+        {{- with .Values.sidecarContainers }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.initContainers }}
       initContainers:
         {{- toYaml . | nindent 8 }}

--- a/charts/warpstream-agent/values.yaml
+++ b/charts/warpstream-agent/values.yaml
@@ -396,6 +396,10 @@ hostAliases: []
 # Labels to be added to each agent pod
 podLabels: {}
 
+# Optional sidecarContainers definition
+# Each of these will be added to the pod as another container
+sidecarContainers: []
+
 # Optional initContainers definition
 initContainers: []
 


### PR DESCRIPTION
This adds a `sidecarContainers` variable, an array, which is appended to the list of `containers` in the Deployment's pod spec. This allows for shipping sidecars with the pod.

Quick test:
```
$ helm template warpstream -f values.yaml charts/warpstream-agent > no-sidecars.yaml
$ helm template warpstream -f values.yaml charts/warpstream-agent > with-sidecars.yaml
$ diff -C 10 no-sidecars.yaml with-sidecars.yaml
*** no-sidecars.yaml    2025-09-26 15:54:34.942231868 -0400
--- with-sidecars.yaml  2025-09-26 15:54:54.483738571 -0400
***************
*** 279,298 ****
--- 279,305 ----
              - name: kafka
                containerPort: 9092
                protocol: TCP
              - name: http
                containerPort: 8080
                protocol: TCP
            volumeMounts:
              - name: agent-key
                mountPath: /app/agent-key
                readOnly: true
+         - command:
+           - /foo/cmd/main
+           env:
+           - name: ENV
+             value: prod
+           image: foo@v1
+           name: foo-sidecar
        volumes:
          - name: agent-key
            secret:
              secretName: warpstream-warpstream-agent-apikey
  ---
  # Source: warpstream-agent/templates/hpa.yaml
  apiVersion: autoscaling/v2
  kind: HorizontalPodAutoscaler
  metadata:
    name: warpstream-warpstream-agent
```