### PR TITLE
Enhance dedicated metrics mode

### DIFF
--- a/charts/warpstream-agent/CHANGELOG.md
+++ b/charts/warpstream-agent/CHANGELOG.md
@@ -6,14 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.0.26] - 2026-04-21
-- Add a new "dedicatedMetricsPod.extraEnv" value the ability to override env variables only for the dedicated metrics pod, and ignore the top level value now for this pod.
-- Add "dedicatedMetricsPod.prometheus" (true by default) and "dedicatedMetricsPod.datadogEnabled" (false by default) values to easily control what metrics settings are enabled when using the dedicated metrics pod.
+- Add a new "dedicatedMetricsPod.extraEnv" value to override env variables only for the dedicated metrics pod, and ignore the top level value now for this pod.
+- Add "dedicatedMetricsPod.prometheusEnabled" (true by default) and "dedicatedMetricsPod.datadogEnabled" (false by default) values to easily control what metrics settings are enabled when using the dedicated metrics pod.
 
 ## [1.0.25] - 2026-04-20
 - Update WarpStream Agent to v784
 
 ## [1.0.24] - 2026-04-17
-- Add a new "dedicatedMetricsPod.extraEnv" value the ability to override env variables only for the dedicated metrics pod, and ignore the top level value now for this pod.
+- Add a new "dedicatedMetricsPod.extraEnv" value to override env variables only for the dedicated metrics pod, and ignore the top level value now for this pod.
 
 ## [1.0.23] - 2026-04-16
 - Update WarpStream Agent to v783

--- a/charts/warpstream-agent/CHANGELOG.md
+++ b/charts/warpstream-agent/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.26] - 2026-04-21
+- Add a new "dedicatedMetricsPod.extraEnv" value the ability to override env variables only for the dedicated metrics pod, and ignore the top level value now for this pod.
+- Add "dedicatedMetricsPod.prometheus" (true by default) and "dedicatedMetricsPod.datadogEnabled" (false by default) values to easily control what metrics settings are enabled when using the dedicated metrics pod.
+
 ## [1.0.25] - 2026-04-20
 - Update WarpStream Agent to v784
 

--- a/charts/warpstream-agent/Chart.yaml
+++ b/charts/warpstream-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: warpstream-agent
 description: WarpStream Agent for Kubernetes.
 type: application
-version: 1.0.25
+version: 1.0.26
 appVersion: v784
 annotations:
   appVersionStable: v766

--- a/charts/warpstream-agent/templates/deployment-metrics.yaml
+++ b/charts/warpstream-agent/templates/deployment-metrics.yaml
@@ -69,7 +69,7 @@ spec:
           args:
             - metrics
             - -agentKeyPath=/app/agent-key/{{ include "warpstream-agent.agentKey.secretKey" . }}
-            {{- range .Values.extraArgs }}
+            {{- range .Values.dedicatedMetricsPod.extraArgs }}
             - {{ . }}
             {{- end }}
           readinessProbe:
@@ -93,6 +93,14 @@ spec:
               {{- $goMaxProcs := divf $cpuMillicoresRequest 1000 -}}
               {{- $goMaxProcs := ceil $goMaxProcs }}
               value: {{ $goMaxProcs | quote }}
+            {{ if .Values.dedicatedMetricsPod.prometheusEnabled }}
+            - name: WARPSTREAM_ENABLE_PROMETHEUS_METRICS
+              value: "true"
+            {{ end -}}
+            {{ if .Values.dedicatedMetricsPod.datadogEnabled }}
+            - name: WARPSTREAM_ENABLE_DATADOG_METRICS
+              value: "true"
+            {{ end -}}
           {{- if .Values.dedicatedMetricsPod.extraEnv }}
             {{- toYaml .Values.dedicatedMetricsPod.extraEnv | nindent 12 }}
           {{- end }}

--- a/charts/warpstream-agent/values.yaml
+++ b/charts/warpstream-agent/values.yaml
@@ -534,6 +534,8 @@ networkPolicy:
 
 dedicatedMetricsPod:
   enabled: false
+  prometheusEnabled: true
+  datadogEnabled: false
   resources:
     # This pod should not require too much memory.
     requests:
@@ -553,6 +555,9 @@ dedicatedMetricsPod:
     labels: {}
   # Add additional environment settings to the pod. The one at the top level is not used toe dedicated metrics pod.
   extraEnv: []
+  # Add additional args settings to the pod.  The one at the top level is not used toe dedicated metrics pod.
+  extraArgs: []
+
 
     # If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted
     # to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature.


### PR DESCRIPTION
- Make it easier to configure datadog/prometheus
- Make `extraArgs` consistent with `extraEnv` in dedicated metrics mode to ease usage