### PR TITLE
Make bucket URL required for Tableflow

### DIFF
--- a/charts/warpstream-agent/CHANGELOG.md
+++ b/charts/warpstream-agent/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.27] - 2026-04-21
+- Require `config.bucketURL` or both `config.ingestionBucketURL` and `config.compactionBucketURL`, including for tableflow agents.
+
 ## [1.0.26] - 2026-04-21
 - Add a new "dedicatedMetricsPod.extraEnv" value to override env variables only for the dedicated metrics pod, and ignore the top level value now for this pod.
 - Add "dedicatedMetricsPod.prometheusEnabled" (true by default) and "dedicatedMetricsPod.datadogEnabled" (false by default) values to easily control what metrics settings are enabled when using the dedicated metrics pod.

--- a/charts/warpstream-agent/CHANGELOG.md
+++ b/charts/warpstream-agent/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.0.27] - 2026-04-21
-- Require `config.bucketURL` or both `config.ingestionBucketURL` and `config.compactionBucketURL`, including for tableflow agents.
+- **Breaking for Tableflow**: Require `config.bucketURL` or both `config.ingestionBucketURL` and `config.compactionBucketURL`, including for tableflow agents.
 
 ## [1.0.26] - 2026-04-21
 - Add a new "dedicatedMetricsPod.extraEnv" value to override env variables only for the dedicated metrics pod, and ignore the top level value now for this pod.

--- a/charts/warpstream-agent/Chart.yaml
+++ b/charts/warpstream-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: warpstream-agent
 description: WarpStream Agent for Kubernetes.
 type: application
-version: 1.0.26
+version: 1.0.27
 appVersion: v784
 annotations:
   appVersionStable: v766

--- a/charts/warpstream-agent/templates/configmap.yaml
+++ b/charts/warpstream-agent/templates/configmap.yaml
@@ -26,8 +26,8 @@ data:
   WARPSTREAM_INGESTION_BUCKET_URL: {{ .Values.config.ingestionBucketURL | quote }}
   WARPSTREAM_COMPACTION_BUCKET_URL: {{ .Values.config.compactionBucketURL | quote }}
     {{- else }}
-      {{- if and (not .Values.config.bucketURL) (not (hasPrefix "vci_dl" .Values.config.virtualClusterID)) }}
-        {{- fail "bucketURL or ingestionBucketURL configuration value must be set" }}
+      {{- if not .Values.config.bucketURL }}
+        {{- fail "bucketURL or both ingestionBucketURL and compactionBucketURL configuration values must be set (including for Tableflow clusters)" }}
       {{- end }}
   WARPSTREAM_BUCKET_URL: {{ .Values.config.bucketURL | quote }}
       {{- if not .Values.config.virtualClusterID }}


### PR DESCRIPTION
We made this not required initially because Tableflow didn't need it, but now with events and other features we're adding to Tableflow its actually important that every Tableflow cluster have a bucket they can target for cluster data.