### PR TITLE
Add externalTrafficPolicy and nodePort to agent services

### DIFF
--- a/charts/warpstream-agent/CHANGELOG.md
+++ b/charts/warpstream-agent/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.31] - 2026-04-28
+- Add support for `externalTrafficPolicy` and `nodePort` on `service`, `kafkaService`, `schemaRegistryService`, `bentoService`, and `dedicatedMetricsPod.service`. This allows using `externalTrafficPolicy: Local` with a static `nodePort` to avoid registering every node in the cluster as a LoadBalancer target and to keep security group rules stable across deploys.
+
 ## [1.0.30] - 2026-04-28
 - Update WarpStream Agent to v786
 

--- a/charts/warpstream-agent/Chart.yaml
+++ b/charts/warpstream-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: warpstream-agent
 description: WarpStream Agent for Kubernetes.
 type: application
-version: 1.0.30
+version: 1.0.31
 appVersion: v786
 annotations:
   appVersionStable: v766

--- a/charts/warpstream-agent/README.md
+++ b/charts/warpstream-agent/README.md
@@ -408,6 +408,59 @@ extraEnv:
 `LoadBalancer` could expose internal WarpStream Agent functionality like the agent-to-agent communication endpoints 
 or the Bento Managed pipeline endpoints.
 
+### Restricting LoadBalancer Target Nodes with `externalTrafficPolicy` and Static NodePorts
+
+When exposing the WarpStream Agent through a cloud load balancer (for example an AWS NLB) using `type: LoadBalancer` with `targetType: instance`, the load balancer registers **every** node in the cluster as a target by default (`externalTrafficPolicy: Cluster`). With NLB client IP preservation, this requires you to open the NodePort range (30000-32767) on the security group of every node in the cluster, which exposes nodes that are not running WarpStream to public traffic. The dynamically allocated NodePort also makes it hard to manage security group rules in tools like Terraform.
+
+Setting `externalTrafficPolicy: Local` causes the LoadBalancer to only register nodes that are actually running WarpStream pods (other nodes will fail health checks and be deregistered). Pairing this with a static `nodePort` lets you predefine security group rules that don't change between deploys.
+
+```yaml
+kafkaService:
+  enabled: true
+  type: LoadBalancer
+  # Only register nodes running WarpStream pods as LB targets.
+  externalTrafficPolicy: Local
+  # Use a static nodePort so security group rules are stable across deploys.
+  nodePort: 30093
+
+extraEnv:
+  - name: WARPSTREAM_DISCOVERY_KAFKA_HOSTNAME_OVERRIDE
+    value: <LOAD_BALANCER_DNS_HOSTNAME>
+```
+
+The same pattern works for the other services. The main `service` exposes multiple ports so its `nodePort` is a map keyed by port name:
+
+```yaml
+service:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  nodePorts:
+    kafka: 30092
+    http: 30080
+    schemaRegistry: 30094
+
+schemaRegistryService:
+  enabled: true
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  nodePort: 30094
+
+bentoService:
+  enabled: true
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  nodePort: 30095
+
+dedicatedMetricsPod:
+  enabled: true
+  service:
+    type: NodePort
+    externalTrafficPolicy: Local
+    nodePort: 30081
+```
+
+**Note:** `externalTrafficPolicy` and `nodePort` are only valid for services of type `NodePort` or `LoadBalancer` and will be rejected by the Kubernetes API if set on a `ClusterIP` service. Using `externalTrafficPolicy: Local` requires healthy WarpStream pods on a node for that node to receive traffic; pair this with anti-affinity or topology spread constraints if you need traffic distributed across zones.
+
 ### Metrics
 
 WarpStream supports exposing metrics with Prometheus and Datadog. For more information see [Monitoring](https://docs.warpstream.com/warpstream/byoc/monitor-the-warpstream-agents) and [Important Metrics and Logs](https://docs.warpstream.com/warpstream/byoc/monitor-the-warpstream-agents/important-metrics-and-logs).
@@ -951,6 +1004,10 @@ It is important to note that if you were already using our charts and you want t
 | service.schemaRegistryPort | number | `9094` | |
 | service.labels | object | `{}` | Additional labels to add to the service |
 | service.loadBalancerSourceRanges | list | `[]` | |
+| service.externalTrafficPolicy | string | `` | Optional `externalTrafficPolicy` (`Cluster` or `Local`). Only valid for type `NodePort` or `LoadBalancer`. Use `Local` to restrict LoadBalancer target nodes to those running WarpStream pods. Ref: https://kubernetes.io/docs/reference/networking/virtual-ips/#external-traffic-policy |
+| service.nodePorts.kafka | number | `` | Optional static nodePort for the kafka port. Only valid for type `NodePort` or `LoadBalancer`. |
+| service.nodePorts.http | number | `` | Optional static nodePort for the http port. Only valid for type `NodePort` or `LoadBalancer`. |
+| service.nodePorts.schemaRegistry | number | `` | Optional static nodePort for the schema-registry port. Only valid for type `NodePort` or `LoadBalancer`. |
 | service.perPod | bool | `false` | Create a unique service for each Kubernetes pod, typically only used when using Kong or Istio ingresses |
 | headlessService.enabled | bool | `false` | Enable the headless service |
 | kafkaService.enabled | bool | `false` | Enable the additional kafka service |
@@ -958,15 +1015,21 @@ It is important to note that if you were already using our charts and you want t
 | kafkaService.loadBalancerClass | string | `` | Optional load balancer class |
 | kafkaService.port | number | `9092` | |
 | kafkaService.loadBalancerSourceRanges | list | `[]` | |
+| kafkaService.externalTrafficPolicy | string | `` | Optional `externalTrafficPolicy` (`Cluster` or `Local`). Only valid for type `NodePort` or `LoadBalancer`. Use `Local` to restrict LoadBalancer target nodes to those running WarpStream pods. Ref: https://kubernetes.io/docs/reference/networking/virtual-ips/#external-traffic-policy |
+| kafkaService.nodePort | number | `` | Optional static nodePort. Only valid for type `NodePort` or `LoadBalancer`. |
 | bentoService.enabled | bool | `false` | Enable if using the HTTP Bento Component https://warpstreamlabs.github.io/bento/docs/components/http/about/ when using WarpStream's Managed Data Pipelines |
 | bentoService.type | string | `ClusterIP` | |
 | bentoService.loadBalancerClass | string | `` | Optional load balancer class |
 | bentoService.port | number | `4195` | |
 | bentoService.extraPorts | list | `[]` | Additional ports to add to the bento service |
+| bentoService.externalTrafficPolicy | string | `` | Optional `externalTrafficPolicy` (`Cluster` or `Local`). Only valid for type `NodePort` or `LoadBalancer`. Ref: https://kubernetes.io/docs/reference/networking/virtual-ips/#external-traffic-policy |
+| bentoService.nodePort | number | `` | Optional static nodePort. Only valid for type `NodePort` or `LoadBalancer`. |
 | schemaRegistryService.enabled | bool | `false` | Enable the additional schema registry service |
 | schemaRegistryService.type | string | `ClusterIP` | |
 | schemaRegistryService.loadBalancerClass | string | `` | Optional load balancer class |
 | schemaRegistryService.port | number | `9094` | |
+| schemaRegistryService.externalTrafficPolicy | string | `` | Optional `externalTrafficPolicy` (`Cluster` or `Local`). Only valid for type `NodePort` or `LoadBalancer`. Use `Local` to restrict LoadBalancer target nodes to those running WarpStream pods. Ref: https://kubernetes.io/docs/reference/networking/virtual-ips/#external-traffic-policy |
+| schemaRegistryService.nodePort | number | `` | Optional static nodePort. Only valid for type `NodePort` or `LoadBalancer`. |
 | config.configMapEnabled | bool | `true` | Enable create the configmap to configure the WarpStream Agents, only set to `false` if you are configuring the agent via `extraEnv` or `extraEnvFrom` |
 | config.playground | bool | `false` | Enable playground mode Ref: https://docs.warpstream.com/warpstream/reference/cli-reference/warpstream-playground |
 | config.bucketURL | string | ` ` | The bucket URL to use for storage |
@@ -1007,6 +1070,8 @@ It is important to note that if you were already using our charts and you want t
 | dedicatedMetricsPod.prometheusEnabled | bool | `true` | Enable/disable Prometheus metrics in agents |
 | dedicatedMetricsPod.datadogEnabled | bool | `false` | Enable/disable Datadog metrics in agents |
 | dedicatedMetricsPod.datadogDefaultAgentHost| bool | `true` | Enable/disable setting the env var DD_AGENT_HOST derived from the underlying host IP when Datadog metrics is enabled |
+| dedicatedMetricsPod.service.externalTrafficPolicy | string | `` | Optional `externalTrafficPolicy` (`Cluster` or `Local`). Only valid for type `NodePort` or `LoadBalancer`. Ref: https://kubernetes.io/docs/reference/networking/virtual-ips/#external-traffic-policy |
+| dedicatedMetricsPod.service.nodePort | number | `` | Optional static nodePort. Only valid for type `NodePort` or `LoadBalancer`. |
 
 ## Development
 

--- a/charts/warpstream-agent/templates/service-bento.yaml
+++ b/charts/warpstream-agent/templates/service-bento.yaml
@@ -15,11 +15,17 @@ spec:
   {{- if .Values.bentoService.loadBalancerClass }}
   loadBalancerClass: {{ .Values.bentoService.loadBalancerClass }}
   {{- end }}
+  {{- with .Values.bentoService.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ . }}
+  {{- end }}
   ports:
     - port: {{ .Values.bentoService.port }}
       targetPort: {{ .Values.bentoService.port }}
       protocol: TCP
       name: http
+      {{- with .Values.bentoService.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
     {{- with .Values.bentoService.extraPorts }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/warpstream-agent/templates/service-kafka.yaml
+++ b/charts/warpstream-agent/templates/service-kafka.yaml
@@ -17,11 +17,17 @@ spec:
   {{- if .Values.kafkaService.loadBalancerClass }}
   loadBalancerClass: {{ .Values.kafkaService.loadBalancerClass }}
   {{- end }}
+  {{- with .Values.kafkaService.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ . }}
+  {{- end }}
   ports:
     - port: {{ .Values.kafkaService.port }}
       targetPort: kafka
       protocol: TCP
       name: kafka
+      {{- with .Values.kafkaService.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
   selector:
     {{- include "warpstream-agent.selectorLabels" . | nindent 4 }}
   {{- with .Values.kafkaService.loadBalancerSourceRanges }}

--- a/charts/warpstream-agent/templates/service-metrics.yaml
+++ b/charts/warpstream-agent/templates/service-metrics.yaml
@@ -21,11 +21,17 @@ spec:
   {{- if .Values.dedicatedMetricsPod.service.loadBalancerClass }}
   loadBalancerClass: {{ .Values.dedicatedMetricsPod.service.loadBalancerClass }}
   {{- end }}
+  {{- with .Values.dedicatedMetricsPod.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ . }}
+  {{- end }}
   ports:
     - port: {{ .Values.dedicatedMetricsPod.service.httpPort }}
       targetPort: http
       protocol: TCP
       name: http
+      {{- with .Values.dedicatedMetricsPod.service.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
   selector:
     {{- include "warpstream-agent.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: agent-metrics

--- a/charts/warpstream-agent/templates/service-schema-registry.yaml
+++ b/charts/warpstream-agent/templates/service-schema-registry.yaml
@@ -17,11 +17,17 @@ spec:
   {{- if .Values.schemaRegistryService.loadBalancerClass }}
   loadBalancerClass: {{ .Values.schemaRegistryService.loadBalancerClass }}
   {{- end }}
+  {{- with .Values.schemaRegistryService.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ . }}
+  {{- end }}
   ports:
     - port: {{ .Values.schemaRegistryService.port }}
       targetPort: schema-registry
       protocol: TCP
       name: schema-registry
+      {{- with .Values.schemaRegistryService.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
   selector:
     {{- include "warpstream-agent.selectorLabels" . | nindent 4 }}
   {{- with .Values.schemaRegistryService.loadBalancerSourceRanges }}

--- a/charts/warpstream-agent/templates/service.yaml
+++ b/charts/warpstream-agent/templates/service.yaml
@@ -25,22 +25,34 @@ spec:
   {{- if $.Values.service.loadBalancerClass }}
   loadBalancerClass: {{ $.Values.service.loadBalancerClass }}
   {{- end }}
+  {{- with $.Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ . }}
+  {{- end }}
   ports:
     {{- if or ($.Values.config.playground) (not (hasPrefix "vci_sr_" ($.Values.config.virtualClusterID | default ""))) }}
     - port: {{ $.Values.service.port }}
       targetPort: kafka
       protocol: TCP
       name: kafka
+      {{- with (($.Values.service.nodePorts).kafka) }}
+      nodePort: {{ . }}
+      {{- end }}
     {{- end }}
     - port: {{ $.Values.service.httpPort }}
       targetPort: http
       protocol: TCP
       name: http
+      {{- with (($.Values.service.nodePorts).http) }}
+      nodePort: {{ . }}
+      {{- end }}
     {{- if or ($.Values.config.playground) (hasPrefix "vci_sr_" ($.Values.config.virtualClusterID | default "")) }}
     - port: {{ $.Values.service.schemaRegistryPort | default 9094 }}
       targetPort: schema-registry
       protocol: TCP
       name: schema-registry
+      {{- with (($.Values.service.nodePorts).schemaRegistry) }}
+      nodePort: {{ . }}
+      {{- end }}
     {{- end }}
   selector:
     {{- include "warpstream-agent.selectorLabels" $ | nindent 4 }}
@@ -77,6 +89,9 @@ spec:
   type: {{ $.Values.service.type }}
   {{- if $.Values.service.loadBalancerClass }}
   loadBalancerClass: {{ $.Values.service.loadBalancerClass }}
+  {{- end }}
+  {{- with $.Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ . }}
   {{- end }}
   ports:
     {{- if or ($.Values.config.playground) (not (hasPrefix "vci_sr_" ($.Values.config.virtualClusterID | default ""))) }}

--- a/charts/warpstream-agent/values.yaml
+++ b/charts/warpstream-agent/values.yaml
@@ -198,6 +198,19 @@ service:
   # https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class
   # loadBalancerClass: ""
 
+  # Optional externalTrafficPolicy. Only valid for type NodePort or LoadBalancer.
+  # Setting this to "Local" causes the LoadBalancer to only register nodes running
+  # WarpStream pods, which avoids exposing NodePorts on every node in the cluster.
+  # https://kubernetes.io/docs/reference/networking/virtual-ips/#external-traffic-policy
+  # externalTrafficPolicy: ""
+
+  # Optional static nodePort assignment per port. Only valid for type NodePort or LoadBalancer.
+  # When unset, Kubernetes will dynamically allocate a nodePort from the configured range.
+  # nodePorts:
+  #   kafka: 30092
+  #   http: 30080
+  #   schemaRegistry: 30094
+
   # Create services per pod, this can be used in combination with deploymentKind=StatefulSet and statefulSetConfig.clusterDomain
   # to expose each pod outside of the cluster when using Kong or Isto ingresses.
   # See https://github.com/warpstreamlabs/charts/pull/156 for details
@@ -220,6 +233,16 @@ kafkaService:
   # https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class
   # loadBalancerClass: ""
 
+  # Optional externalTrafficPolicy. Only valid for type NodePort or LoadBalancer.
+  # Setting this to "Local" causes the LoadBalancer to only register nodes running
+  # WarpStream pods, which avoids exposing NodePorts on every node in the cluster.
+  # https://kubernetes.io/docs/reference/networking/virtual-ips/#external-traffic-policy
+  # externalTrafficPolicy: ""
+
+  # Optional static nodePort. Only valid for type NodePort or LoadBalancer.
+  # When unset, Kubernetes will dynamically allocate a nodePort from the configured range.
+  # nodePort: 30092
+
 # A service that only contains the Schema Registry TCP port
 # Typically used to help with exposing only Schema Registry via a Load Balancer
 schemaRegistryService:
@@ -236,6 +259,16 @@ schemaRegistryService:
   # https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class
   # loadBalancerClass: ""
 
+  # Optional externalTrafficPolicy. Only valid for type NodePort or LoadBalancer.
+  # Setting this to "Local" causes the LoadBalancer to only register nodes running
+  # WarpStream pods, which avoids exposing NodePorts on every node in the cluster.
+  # https://kubernetes.io/docs/reference/networking/virtual-ips/#external-traffic-policy
+  # externalTrafficPolicy: ""
+
+  # Optional static nodePort. Only valid for type NodePort or LoadBalancer.
+  # When unset, Kubernetes will dynamically allocate a nodePort from the configured range.
+  # nodePort: 30094
+
 # Enable if using the HTTP Bento Component https://warpstreamlabs.github.io/bento/docs/components/http/about/
 # when using WarpStream's Managed Data Pipelines
 bentoService:
@@ -251,6 +284,16 @@ bentoService:
   # If using type LoadBalancer set an optional loadBalancerClass
   # https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class
   # loadBalancerClass: ""
+
+  # Optional externalTrafficPolicy. Only valid for type NodePort or LoadBalancer.
+  # Setting this to "Local" causes the LoadBalancer to only register nodes running
+  # WarpStream pods, which avoids exposing NodePorts on every node in the cluster.
+  # https://kubernetes.io/docs/reference/networking/virtual-ips/#external-traffic-policy
+  # externalTrafficPolicy: ""
+
+  # Optional static nodePort. Only valid for type NodePort or LoadBalancer.
+  # When unset, Kubernetes will dynamically allocate a nodePort from the configured range.
+  # nodePort: 30095
 
 rbac:
   create: true
@@ -566,11 +609,6 @@ dedicatedMetricsPod:
     type: ClusterIP
     httpPort: 8080
     labels: {}
-  # Add additional environment settings to the pod. The one at the top level is not used toe dedicated metrics pod.
-  extraEnv: []
-  # Add additional args settings to the pod.  The one at the top level is not used toe dedicated metrics pod.
-  extraArgs: []
-
 
     # If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted
     # to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature.
@@ -580,6 +618,20 @@ dedicatedMetricsPod:
     # If using type LoadBalancer set an optional loadBalancerClass
     # https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class
     # loadBalancerClass: ""
+
+    # Optional externalTrafficPolicy. Only valid for type NodePort or LoadBalancer.
+    # Setting this to "Local" causes the LoadBalancer to only register nodes running
+    # WarpStream pods, which avoids exposing NodePorts on every node in the cluster.
+    # https://kubernetes.io/docs/reference/networking/virtual-ips/#external-traffic-policy
+    # externalTrafficPolicy: ""
+
+    # Optional static nodePort. Only valid for type NodePort or LoadBalancer.
+    # When unset, Kubernetes will dynamically allocate a nodePort from the configured range.
+    # nodePort: 30081
+  # Add additional environment settings to the pod. The one at the top level is not used toe dedicated metrics pod.
+  extraEnv: []
+  # Add additional args settings to the pod.  The one at the top level is not used toe dedicated metrics pod.
+  extraArgs: []
   serviceMonitor:
     ## If true, a ServiceMonitor CRD is created for a prometheus operator
     ## https://github.com/coreos/prometheus-operator


### PR DESCRIPTION
## Summary
- Add `externalTrafficPolicy` and `nodePort` support to all five services in the warpstream-agent chart: `service`, `kafkaService`, `schemaRegistryService`, `bentoService`, and `dedicatedMetricsPod.service`. Both fields are only rendered when set, so existing configurations are unchanged.
- The main `service` exposes multiple ports (`kafka`, `http`, `schema-registry`), so its per-port nodePort is exposed as a `service.nodePorts` map keyed by port name. The per-pod variant of the main service applies `externalTrafficPolicy` but intentionally omits `nodePort` since a hardcoded nodePort would conflict across the per-pod services.
- Document the new values in `values.yaml` and the README values reference table, and add a "Restricting LoadBalancer Target Nodes with externalTrafficPolicy and Static NodePorts" section to the README explaining the customer use case (avoiding registering every node in the cluster as an NLB target and avoiding NodePort churn that breaks stable security group rules).
- Bump chart version to `1.0.31` with a CHANGELOG entry.

## Test plan
- [x] `helm lint charts/warpstream-agent` (passes; pre-existing networkpolicy warning is unrelated)
- [x] `helm template` with defaults → no `externalTrafficPolicy` or `nodePort` fields rendered (backwards compatible)
- [x] `helm template` with `kafkaService` configured for the customer's case (`type: LoadBalancer`, `externalTrafficPolicy: Local`, `nodePort: 30093`) renders the expected spec
- [x] `helm template` with each of the other services (`service`, `schemaRegistryService`, `bentoService`, `dedicatedMetricsPod.service`) confirms `externalTrafficPolicy` and `nodePort` render correctly
- [x] `helm template` with `service.perPod.enabled=true` confirms the per-pod services pick up `externalTrafficPolicy` and do not get a (conflicting) shared nodePort

🤖 Generated with [Claude Code](https://claude.com/claude-code)