### PR TITLE
Fix customDeployments cert secret and add aggregate Service

### DIFF
--- a/charts/warpstream-agent/CHANGELOG.md
+++ b/charts/warpstream-agent/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.36] - 2026-05-04
+- Fix `agent-certs` volume referencing a non-existent secret when `customDeployments` is set with `certificate.certManager.create=true`. The volume now points at the single Certificate (`{fullname}-cert`) instead of incorrectly appending the customDeployment name.
+- When `customDeployments` is set, also create an aggregate Service named after the chart fullname (no per-deployment suffix) that selects pods across every customDeployment. This restores the original Service name for clients that were pointing at it before `customDeployments` was enabled. Set `service.includeAggregateService: false` to opt out.
+
 ## [1.0.35] - 2026-04-30
 - Update WarpStream Agent to v789
 

--- a/charts/warpstream-agent/Chart.yaml
+++ b/charts/warpstream-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: warpstream-agent
 description: WarpStream Agent for Kubernetes.
 type: application
-version: 1.0.35
+version: 1.0.36
 appVersion: v789
 annotations:
   appVersionStable: v766

--- a/charts/warpstream-agent/templates/deployment.yaml
+++ b/charts/warpstream-agent/templates/deployment.yaml
@@ -305,7 +305,7 @@ spec:
         {{- if and .certManager .certManager.create }}
         - name: agent-certs
           secret:
-            secretName: {{ $fullName }}-cert
+            secretName: {{ include "warpstream-agent.fullname" $ }}-cert
         {{- else }}
         - name: agent-certs
           secret:

--- a/charts/warpstream-agent/templates/service.yaml
+++ b/charts/warpstream-agent/templates/service.yaml
@@ -66,6 +66,72 @@ spec:
     {{- end }}
   {{- end }}
 ...
+{{- end }}
+{{- if and (hasKey .Values "customDeployments") (ne .Values.service.includeAggregateService false) }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "warpstream-agent.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "warpstream-agent.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    prometheus: "true"
+    app.kubernetes.io/component: agent
+  {{- with (mergeOverwrite (default (dict) .Values.annotations) (default (dict) .Values.service.annotations)) }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.service.loadBalancerClass }}
+  {{- end }}
+  {{- with .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ . }}
+  {{- end }}
+  ports:
+    {{- if or (.Values.config.playground) (not (hasPrefix "vci_sr_" (.Values.config.virtualClusterID | default ""))) }}
+    - port: {{ .Values.service.port }}
+      targetPort: kafka
+      protocol: TCP
+      name: kafka
+      {{- with ((.Values.service.nodePorts).kafka) }}
+      nodePort: {{ . }}
+      {{- end }}
+    {{- end }}
+    - port: {{ .Values.service.httpPort }}
+      targetPort: http
+      protocol: TCP
+      name: http
+      {{- with ((.Values.service.nodePorts).http) }}
+      nodePort: {{ . }}
+      {{- end }}
+    {{- if or (.Values.config.playground) (hasPrefix "vci_sr_" (.Values.config.virtualClusterID | default "")) }}
+    - port: {{ .Values.service.schemaRegistryPort | default 9094 }}
+      targetPort: schema-registry
+      protocol: TCP
+      name: schema-registry
+      {{- with ((.Values.service.nodePorts).schemaRegistry) }}
+      nodePort: {{ . }}
+      {{- end }}
+    {{- end }}
+  selector:
+    {{- include "warpstream-agent.selectorLabels" . | nindent 4 }}
+  {{- with .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- range . }}
+    - {{ . }}
+    {{- end }}
+  {{- end }}
+...
+{{- end }}
+{{- range $customDeployment := $deployments }}
+{{- $suffix := (hasKey $.Values "customDeployments") | ternary (printf "-%s" .name) "" }}
+{{- $fullName := printf "%s%s" (include "warpstream-agent.fullname" $) $suffix }}
 {{- if $.Values.service.perPod }}
 {{- if and (eq (include "warpstream-agent.deploymentKind" $) "StatefulSet") ($.Values.service.perPod.enabled) }}
 {{ $replicas := ($.Values.replicas | int) }}

--- a/charts/warpstream-agent/values.yaml
+++ b/charts/warpstream-agent/values.yaml
@@ -189,6 +189,13 @@ service:
   schemaRegistryPort: 9094
   labels: {}
 
+  # When `customDeployments` is set, the chart also creates an aggregate Service
+  # named after the chart fullname (with no per-deployment suffix) that selects
+  # pods across every customDeployment. This preserves the original Service name
+  # for clients that were pointing at it before customDeployments was enabled.
+  # Set to false to skip creating this aggregate Service.
+  includeAggregateService: true
+
   # If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted
   # to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature.
   # More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/


### PR DESCRIPTION
## Summary
- When `customDeployments` is set with `certificate.certManager.create=true`, the `agent-certs` volume referenced a secret that never existed (`{fullname}-{deploymentName}-cert`). The Certificate template only ever creates one cert at `{fullname}-cert`, so pods failed to mount their TLS material. Fixed the volume to reference the actual Certificate's secret.
- When `customDeployments` is set, only per-deployment Services were created (e.g. `{fullname}-us-west-2a`), removing the original `{fullname}` Service that customer clients were pointed at. Added an aggregate Service named `{fullname}` that selects pods across every customDeployment. Opt out via `service.includeAggregateService: false`.

## Test plan
- [x] `helm template` with customer's customDeployments + cert-manager values renders `agent-certs.secretName: {fullname}-cert` (matches the Certificate) for every per-AZ Deployment.
- [x] `helm template` produces both per-AZ Services and an aggregate `{fullname}` Service whose selector matches every customDeployment's pods.
- [x] No-customDeployments case is unchanged: single Service, single cert reference.
- [x] StatefulSet + customDeployments + perPod still renders per-pod Services correctly.
- [x] `service.includeAggregateService=false` skips the aggregate Service.
- [x] All existing CI fixtures still render (the one pre-existing `playground-network-policies.yaml` failure also reproduces on `main`, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)