### PR TITLE
Add `autoscaling` overrides support for each deployment defined under customDeployments

### DIFF
--- a/charts/warpstream-agent/CHANGELOG.md
+++ b/charts/warpstream-agent/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.53] - 2026-06-16
+- Add `autoscaling` overrides support for each deployment defined under `customDeployments`
+
 ## [1.0.52] - 2026-06-12
 - Update WarpStream Agent to v807
 

--- a/charts/warpstream-agent/Chart.yaml
+++ b/charts/warpstream-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: warpstream-agent
 description: WarpStream Agent for Kubernetes.
 type: application
-version: 1.0.52
+version: 1.0.53
 appVersion: v807
 annotations:
   appVersionStable: v792

--- a/charts/warpstream-agent/templates/hpa.yaml
+++ b/charts/warpstream-agent/templates/hpa.yaml
@@ -2,8 +2,15 @@
 {{- $defaultDeployments := include "warpstream-agent.customDeploymentsDefault" . | fromYaml -}}
 {{- $deployments := .Values.customDeployments | default $defaultDeployments.deployments -}}
 {{- range $customDeployment := $deployments }}
+{{- $hasAutoscalingEnabledOverride := and (hasKey . "overrides") (hasKey .overrides "autoscaling") (hasKey .overrides.autoscaling "enabled") }}
+{{- if or (not $hasAutoscalingEnabledOverride) (.overrides.autoscaling.enabled) }}
 {{- $suffix := (hasKey $.Values "customDeployments") | ternary (printf "-%s" .name) "" }}
 {{- $fullName := printf "%s%s" (include "warpstream-agent.fullname" $) $suffix }}
+{{- $hasAutoscalingMinReplicasOverride := and (hasKey . "overrides") (hasKey .overrides "autoscaling") (hasKey .overrides.autoscaling "minReplicas") }}
+{{- $hasAutoscalingMaxReplicasOverride := and (hasKey . "overrides") (hasKey .overrides "autoscaling") (hasKey .overrides.autoscaling "maxReplicas") }}
+{{- $hasAutoscalingTargetMemoryOverride := and (hasKey . "overrides") (hasKey .overrides "autoscaling") (hasKey .overrides.autoscaling "targetMemory") }}
+{{- $hasAutoscalingTargetCPUOverride := and (hasKey . "overrides") (hasKey .overrides "autoscaling") (hasKey .overrides.autoscaling "targetCPU") }}
+{{- $hasAutoscalingBehaviorOverride := and (hasKey . "overrides") (hasKey .overrides "autoscaling") (hasKey .overrides.autoscaling "behavior") }}
 ---
 apiVersion: {{ include "warpstream-agent.hpa.apiVersion" $ }}
 kind: HorizontalPodAutoscaler
@@ -22,35 +29,64 @@ spec:
     apiVersion: apps/v1
     kind: {{ include "warpstream-agent.deploymentKind" $ }}
     name: {{ $fullName }}
+  {{- if $hasAutoscalingMinReplicasOverride }}
+  minReplicas: {{ .overrides.autoscaling.minReplicas }}
+  {{- else }}
   minReplicas: {{ $.Values.autoscaling.minReplicas }}
+  {{- end }}
+  {{- if $hasAutoscalingMaxReplicasOverride }}
+  maxReplicas: {{ .overrides.autoscaling.maxReplicas }}
+  {{- else }}
   maxReplicas: {{ $.Values.autoscaling.maxReplicas }}
+  {{- end }}
   metrics:
-    {{- if $.Values.autoscaling.targetMemory }}
+    {{- if or $.Values.autoscaling.targetMemory $hasAutoscalingTargetMemoryOverride }}
     - type: Resource
       resource:
         name: memory
         {{- if eq (include "warpstream-agent.hpa.apiVersion" $) "autoscaling/v2beta1" }}
+        {{- if $hasAutoscalingTargetMemoryOverride }}
+        targetAverageUtilization: {{ .overrides.autoscaling.targetMemory }}
+        {{- else }}
         targetAverageUtilization: {{ $.Values.autoscaling.targetMemory }}
+        {{- end }}
         {{- else }}
         target:
           type: Utilization
+          {{- if $hasAutoscalingTargetMemoryOverride }}
+          averageUtilization: {{ .overrides.autoscaling.targetMemory }}
+          {{- else }}
           averageUtilization: {{ $.Values.autoscaling.targetMemory }}
+          {{- end }}
         {{- end }}
     {{- end }}
-    {{- if $.Values.autoscaling.targetCPU }}
+    {{- if or $.Values.autoscaling.targetCPU $hasAutoscalingTargetCPUOverride }}
     - type: Resource
       resource:
         name: cpu
         {{- if eq (include "warpstream-agent.hpa.apiVersion" $) "autoscaling/v2beta1" }}
+        {{- if $hasAutoscalingTargetCPUOverride }}
+        targetAverageUtilization: {{ .overrides.autoscaling.targetCPU }}
+        {{- else }}
         targetAverageUtilization: {{ $.Values.autoscaling.targetCPU }}
+        {{- end }}
         {{- else }}
         target:
           type: Utilization
+          {{- if $hasAutoscalingTargetCPUOverride }}
+          averageUtilization: {{ .overrides.autoscaling.targetCPU }}
+          {{- else }}
           averageUtilization: {{ $.Values.autoscaling.targetCPU }}
+          {{- end }}
         {{- end }}
     {{- end }}
-  {{- if $.Values.autoscaling.behavior }}
+  {{- if or $.Values.autoscaling.behavior $hasAutoscalingBehaviorOverride }}
+  {{- if $hasAutoscalingBehaviorOverride }}
+  behavior: {{ toYaml .overrides.autoscaling.behavior | nindent 4 }}
+  {{- else }}
   behavior: {{ toYaml $.Values.autoscaling.behavior | nindent 4 }}
   {{- end }}
+  {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/warpstream-agent/values.yaml
+++ b/charts/warpstream-agent/values.yaml
@@ -16,6 +16,28 @@ image:
 #     zone: "us-east-1a"
 #     roles: proxy
 #     agentGroup: default
+#     autoscaling:
+#       enabled: true
+#       minReplicas: 5
+#       maxReplicas: 40
+#       targetCPU: "30"
+#       behavior:
+#         scaleDown:
+#           stabilizationWindowSeconds: 1800
+#           policies:
+#           - type: Pods
+#             value: 1
+#             periodSeconds: 900
+#         scaleUp:
+#           stabilizationWindowSeconds: 0
+#           policies:
+#           - type: Percent
+#             value: 50
+#             periodSeconds: 300
+#           - type: Pods
+#             value: 3
+#             periodSeconds: 300
+#           selectPolicy: Max
 #   extraEnv:
 #   - name: WARPSTREAM_SCHEMA_REGISTRY_BASIC_AUTH_ENABLED
 #     value: "true"


### PR DESCRIPTION
So our customers can easily define different hpas depending on the deployment.