### PR TITLE
Expose cluster level metrics with a dedicated single pod deployment by default

### DIFF
--- a/charts/warpstream-agent/CHANGELOG.md
+++ b/charts/warpstream-agent/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.53] - 2026-06-16
+## [1.0.54] - 2026-06-17
+- Expose cluster level metrics with a dedicated single pod deployment by default (set `dedicatedMetricsPod.enabled` to `true` by default)
+
+## [1.0.53] - 2026-06-17
 - Add `autoscaling` overrides support for each deployment defined under `customDeployments`
 
 ## [1.0.52] - 2026-06-12

--- a/charts/warpstream-agent/Chart.yaml
+++ b/charts/warpstream-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: warpstream-agent
 description: WarpStream Agent for Kubernetes.
 type: application
-version: 1.0.53
+version: 1.0.54
 appVersion: v807
 annotations:
   appVersionStable: v792

--- a/charts/warpstream-agent/README.md
+++ b/charts/warpstream-agent/README.md
@@ -467,7 +467,7 @@ WarpStream supports exposing metrics with Prometheus and Datadog. For more infor
 
 In our charts, we provide values to control easily whether Prometheus and/or Datadog is enabled (see `prometheusEnabled` and `datadogEnabled` in our `values.yaml`).
 
-By default, any agent can publish "cluster level" metrics by polling a job submitted by WarpStream control plane. This can cause weird behaviors as the same metric will be published by different agent pods with inconsistent values. A workaround is to set `dedicatedMetricsPod.enabled` to `true`: it will disable the control plane job, and instead spawn a dedicated deployment of size 1 with a pod that will do the same thing by scrapping WarpStream API. There are flags to control Prometheus and Datadog under `dedicatedMetricsPod` as well.
+A WarpStream agent can publish "cluster level" metrics by polling a job submitted by WarpStream control plane. This can cause weird behaviors as the same metric will be published by different agent pods with inconsistent values. This is why the default way to handle metrics in Kubernetes is to set `dedicatedMetricsPod.enabled` to `true`: it will disable the control plane job, and instead spawn a dedicated deployment of size 1 with a pod that will do the same thing by scrapping WarpStream API. There are flags to control Prometheus and Datadog under `dedicatedMetricsPod` as well. If you do not want this extra deployment, then you can disable this mode by setting `dedicatedMetricsPod.enabled` to `false`.
 
 #### Prometheus Operator
 

--- a/charts/warpstream-agent/README.md
+++ b/charts/warpstream-agent/README.md
@@ -467,7 +467,7 @@ WarpStream supports exposing metrics with Prometheus and Datadog. For more infor
 
 In our charts, we provide values to control easily whether Prometheus and/or Datadog is enabled (see `prometheusEnabled` and `datadogEnabled` in our `values.yaml`).
 
-A WarpStream agent can publish "cluster level" metrics by polling a job submitted by WarpStream control plane. This can cause weird behaviors as the same metric will be published by different agent pods with inconsistent values. This is why the default way to handle metrics in Kubernetes is to set `dedicatedMetricsPod.enabled` to `true`: it will disable the control plane job, and instead spawn a dedicated deployment of size 1 with a pod that will do the same thing by scrapping WarpStream API. There are flags to control Prometheus and Datadog under `dedicatedMetricsPod` as well. If you do not want this extra deployment, then you can disable this mode by setting `dedicatedMetricsPod.enabled` to `false`.
+A WarpStream agent can publish "cluster level" metrics by polling a job submitted by WarpStream control plane. This can cause weird behavior as the same metric will be published by different agent pods with inconsistent values. This is why the default way to handle metrics in Kubernetes is to set `dedicatedMetricsPod.enabled` to `true`: it will disable the control plane job, and instead spawn a dedicated deployment of size 1 with a pod that will do the same thing by scrapping the WarpStream API. There are flags to control Prometheus and Datadog under `dedicatedMetricsPod` as well. If you do not want this extra deployment, then you can disable this mode by setting `dedicatedMetricsPod.enabled` to `false`.
 
 #### Prometheus Operator
 


### PR DESCRIPTION
We believe this is a more robust way to handle metrics, so let's make it the default.