### PR TITLE
Ignore topic creation error

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -103,6 +103,7 @@ jobs:
           kubectl set env -n warpstream-benchmark-playground deployment/warpstream-benchmark-playground WARPSTREAM_ADVERTISE_HOSTNAME_STRATEGY=auto-ip4
           kubectl create svc clusterip -n warpstream-benchmark-playground warpstream-benchmark-playground --tcp=9092:9092
           kubectl wait --for=condition=available --timeout=120s -n warpstream-benchmark-playground deployment/warpstream-benchmark-playground
+          sleep 30
           kubectl exec -it -n warpstream-benchmark-playground deployments/warpstream-benchmark-playground -- /warpstream cli create-topic -topic ws-benchmark
 
       - name: Generate Certificate for TLS testing

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -102,7 +102,7 @@ jobs:
           kubectl create deployment -n warpstream-benchmark-playground warpstream-benchmark-playground --image=public.ecr.aws/warpstream-labs/warpstream_agent:latest -- /warpstream playground
           kubectl set env -n warpstream-benchmark-playground deployment/warpstream-benchmark-playground WARPSTREAM_ADVERTISE_HOSTNAME_STRATEGY=auto-ip4
           kubectl create svc clusterip -n warpstream-benchmark-playground warpstream-benchmark-playground --tcp=9092:9092
-          sleep 30
+          kubectl wait --for=condition=available --timeout=120s -n warpstream-benchmark-playground deployment/warpstream-benchmark-playground
           kubectl exec -it -n warpstream-benchmark-playground deployments/warpstream-benchmark-playground -- /warpstream cli create-topic -topic ws-benchmark
 
       - name: Generate Certificate for TLS testing

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -102,9 +102,8 @@ jobs:
           kubectl create deployment -n warpstream-benchmark-playground warpstream-benchmark-playground --image=public.ecr.aws/warpstream-labs/warpstream_agent:latest -- /warpstream playground
           kubectl set env -n warpstream-benchmark-playground deployment/warpstream-benchmark-playground WARPSTREAM_ADVERTISE_HOSTNAME_STRATEGY=auto-ip4
           kubectl create svc clusterip -n warpstream-benchmark-playground warpstream-benchmark-playground --tcp=9092:9092
-          kubectl wait --for=condition=available --timeout=120s -n warpstream-benchmark-playground deployment/warpstream-benchmark-playground
           sleep 30
-          kubectl exec -it -n warpstream-benchmark-playground deployments/warpstream-benchmark-playground -- /warpstream cli create-topic -topic ws-benchmark
+          kubectl exec -it -n warpstream-benchmark-playground deployments/warpstream-benchmark-playground -- /warpstream cli create-topic -topic ws-benchmark || true
 
       - name: Generate Certificate for TLS testing
         run: |


### PR DESCRIPTION
Fixes
```
error creating topic 'ws-benchmark': TOPIC_ALREADY_EXISTS: Topic with this name already exists.
command terminated with exit code 1
Error: Process completed with exit code 1.
```

This can basically happen when a create topic request succeeds but the response is lost or the caller timed out while waiting for the response. The call gets retried again which will fail with topic already exists. This PR fixes this by ignoring topic creation errors. For the purpose of testing the chart it's not too important that this request succeeds.