### PR TITLE
Support per-customDeployment resources and goMaxProcs overrides

### DIFF
--- a/charts/warpstream-agent/CHANGELOG.md
+++ b/charts/warpstream-agent/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.75] - 2026-08-05
+- Support per-customDeployment `resources` and `goMaxProcs` overrides
+
 ## [1.0.74] - 2026-08-04
 - Update WarpStream Agent to v827
 

--- a/charts/warpstream-agent/Chart.yaml
+++ b/charts/warpstream-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: warpstream-agent
 description: WarpStream Agent for Kubernetes.
 type: application
-version: 1.0.74
+version: 1.0.75
 appVersion: v827
 annotations:
   appVersionStable: v815

--- a/charts/warpstream-agent/README.md
+++ b/charts/warpstream-agent/README.md
@@ -736,6 +736,35 @@ customDeployments:
 
 This will create three warpstream deployments each with their own HPA and the ability to autoscale each zone independently.
 
+#### Resources Per Deployment
+
+By default every custom deployment inherits the root `resources` (and `goMaxProcs`). When custom deployments run
+differently-sized workloads — for example a small dedicated pool for managed pipelines next to a large proxy fleet —
+each deployment can override them:
+
+```yaml
+customDeployments:
+  - name: proxy
+    overrides:
+      roles: proxy
+  - name: pipelines
+    overrides:
+      roles: pipelines
+      resources:
+        requests:
+          cpu: 2
+          memory: 8Gi
+        limits:
+          memory: null
+      # Optional; when omitted, GOMAXPROCS is derived from the overridden CPU
+      # request (unless a root-level goMaxProcs is set, which takes precedence
+      # over derivation but not over this override).
+      goMaxProcs: 2
+```
+
+The `enforceProductionResourceRequirements` check (4 GiB of memory per CPU) applies to overridden resources the same
+way it applies to the root `resources`.
+
 ### Playground Mode
 
 Use playground mode to easily test WarpStream without needing to first create a WarpStream account. See WarpStream's ["Hello World"](https://docs.warpstream.com/warpstream/getting-started/hello-world-using-kafka) to learn more.

--- a/charts/warpstream-agent/README.md
+++ b/charts/warpstream-agent/README.md
@@ -754,8 +754,6 @@ customDeployments:
         requests:
           cpu: 2
           memory: 8Gi
-        limits:
-          memory: null
       # Optional; when omitted, GOMAXPROCS is derived from the overridden CPU
       # request (unless a root-level goMaxProcs is set, which takes precedence
       # over derivation but not over this override).

--- a/charts/warpstream-agent/README.md
+++ b/charts/warpstream-agent/README.md
@@ -754,6 +754,8 @@ customDeployments:
         requests:
           cpu: 2
           memory: 8Gi
+        limits:
+          memory: 8Gi
       # Optional; when omitted, GOMAXPROCS is derived from the overridden CPU
       # request (unless a root-level goMaxProcs is set, which takes precedence
       # over derivation but not over this override).

--- a/charts/warpstream-agent/ci/playground-custom-deployment-resources-values.yaml
+++ b/charts/warpstream-agent/ci/playground-custom-deployment-resources-values.yaml
@@ -1,0 +1,53 @@
+config:
+  playground: true
+
+  # Set to 80s for tests so the tests don't take forever
+  gracefulShutdownDuration: 80s
+
+deploymentStrategy:
+  type: RollingUpdate
+  rollingUpdate: null  # setting rollingUpdate to null so helm will fail if pod doesn't start
+
+# overriding resources so it fits on a runner
+resources:
+  requests:
+    cpu: 500m
+    memory: 2Gi
+    # we do not need the disk space, but Kubernetes will count some logs that it emits
+    # about our containers towards our containers ephemeral usage and if we requested
+    # 0 storage we could end up getting evicted unnecessarily when the node is under disk pressure.
+    ephemeral-storage: "100Mi"
+  limits:
+    memory: 2Gi
+
+# One deployment inheriting the root resources, one overriding them —
+# exercises the per-deployment `overrides.resources` / `overrides.goMaxProcs`
+# path next to the inheritance path.
+customDeployments:
+  - name: default-size
+  - name: small
+    overrides:
+      resources:
+        requests:
+          cpu: 250m
+          memory: 1Gi
+        limits:
+          memory: 1Gi
+      goMaxProcs: 1
+
+kafkaService:
+  enabled: true
+
+extraEnv:
+  - name: WARPSTREAM_ADVERTISE_HOSTNAME_STRATEGY
+    value: auto-ip4  # playground mode defaults to local so we need to override it for tests to pass
+
+# Test resource settings
+test:
+  resources:
+    requests:
+      cpu: 1m
+      memory: 128Mi
+    limits:
+      cpu: 100m
+      memory: 256Mi

--- a/charts/warpstream-agent/templates/deployment.yaml
+++ b/charts/warpstream-agent/templates/deployment.yaml
@@ -148,10 +148,14 @@ spec:
             initialDelaySeconds: 30
             failureThreshold: 5
             periodSeconds: 5
+          {{- $resources := $.Values.resources }}
+          {{- if and (hasKey . "overrides") (hasKey .overrides "resources") }}
+          {{- $resources = .overrides.resources }}
+          {{- end }}
           resources:
             {{- if $.Values.enforceProductionResourceRequirements}}
-              {{- $cpuMillicoresRequest := $.Values.resources.requests.cpu | include "convertToMillicores" -}}
-              {{- $memoryRequest := $.Values.resources.requests.memory | include "convertToBytes" -}}
+              {{- $cpuMillicoresRequest := $resources.requests.cpu | include "convertToMillicores" -}}
+              {{- $memoryRequest := $resources.requests.memory | include "convertToBytes" -}}
               {{- $memoryPerMillicore := divf $memoryRequest $cpuMillicoresRequest -}}
               {{- $memoryPerCPU := mulf $memoryPerMillicore 1000.0 -}}
               {{- $minMemoryPerCPU := 4000000000.0 -}}
@@ -159,7 +163,7 @@ spec:
                 {{ fail (printf "Memory request per CPU (%.2f GiB) is less than the required 4 GiB per CPU. Please increase the memory request." (divf $memoryPerCPU 1073741824)) }}
               {{- end -}}
             {{- end -}}
-            {{- toYaml $.Values.resources | nindent 12 }}
+            {{- toYaml $resources | nindent 12 }}
           env:
             - name: MY_POD_NAME
               valueFrom:
@@ -180,14 +184,15 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.namespace
             - name: GOMAXPROCS
-              {{- if not $.Values.goMaxProcs }}
-              {{- $cpuMillicoresRequest := $.Values.resources.requests.cpu | include "convertToMillicores" -}}
-              {{- $goMaxProcs := divf $cpuMillicoresRequest 1000 -}}
-              {{- $goMaxProcs := ceil $goMaxProcs }}
-              value: {{ $goMaxProcs | quote }}
-              {{- else }}
-              value: {{ $.Values.goMaxProcs | quote }}
+              {{- $goMaxProcs := $.Values.goMaxProcs }}
+              {{- if and (hasKey . "overrides") (hasKey .overrides "goMaxProcs") }}
+              {{- $goMaxProcs = .overrides.goMaxProcs }}
               {{- end }}
+              {{- if not $goMaxProcs }}
+              {{- $cpuMillicoresRequest := $resources.requests.cpu | include "convertToMillicores" -}}
+              {{- $goMaxProcs = divf $cpuMillicoresRequest 1000 | ceil }}
+              {{- end }}
+              value: {{ $goMaxProcs | quote }}
             {{ if $.Values.prometheusEnabled }}
             - name: WARPSTREAM_ENABLE_PROMETHEUS_METRICS
               value: "true"

--- a/charts/warpstream-agent/values.yaml
+++ b/charts/warpstream-agent/values.yaml
@@ -24,6 +24,8 @@ image:
 #       requests:
 #         cpu: 2
 #         memory: 8Gi
+#       limits:
+#         memory: 8Gi
 #     # Optional: override GOMAXPROCS for this deployment only.
 #     goMaxProcs: 2
 #     autoscaling:

--- a/charts/warpstream-agent/values.yaml
+++ b/charts/warpstream-agent/values.yaml
@@ -16,6 +16,16 @@ image:
 #     zone: "us-east-1a"
 #     roles: proxy
 #     agentGroup: default
+#     # Optional: override the pod resources for this deployment only. When
+#     # unset, the deployment uses the root `resources`. When set and
+#     # `goMaxProcs` is not overridden or set at the root, GOMAXPROCS is
+#     # derived from this CPU request.
+#     resources:
+#       requests:
+#         cpu: 2
+#         memory: 8Gi
+#     # Optional: override GOMAXPROCS for this deployment only.
+#     goMaxProcs: 2
 #     autoscaling:
 #       enabled: true
 #       minReplicas: 5


### PR DESCRIPTION
Custom deployments currently inherit the release-wide `resources` block, so a release that mixes differently sized workloads has to size every deployment for the largest one. Our concrete case: a dedicated pool of `pipelines`-role agents (as the [Managed Data Pipelines docs](https://docs.warpstream.com/warpstream/kafka/manage-connectors/bento) recommend for isolating pipelines from Produce/Fetch agents) running next to a large proxy fleet — the pipelines pool carries a small fraction of the traffic but inherits the proxy-sized 14 CPU / 56 GiB request, which pins each of its pods to its own oversized node.

This PR allows per-deployment overrides, falling back to the root values when unset:

```yaml
customDeployments:
  - name: proxy
    overrides:
      roles: proxy
  - name: pipelines
    overrides:
      roles: pipelines
      resources:
        requests:
          cpu: 2
          memory: 8Gi
      goMaxProcs: 2
```

The GOMAXPROCS derivation and the `enforceProductionResourceRequirements` 4 GiB/CPU check both use the effective per-deployment resources — applying the validation to overrides is deliberate, for consistency with the root block. Precedence for GOMAXPROCS: `overrides.goMaxProcs` > root `goMaxProcs` > derived from the effective CPU request.

No behavior change when the overrides are absent: rendered manifests for all eight existing `ci/` values files are byte-identical to `main` apart from the `helm.sh/chart` version label (and the config checksum that follows from it).

Also verified by rendering:

- a deployment with `overrides.resources` gets them while a sibling deployment in the same release keeps the root resources
- a root-level `goMaxProcs` still applies to non-overridden deployments, but loses to a per-deployment `overrides.goMaxProcs`
- with no `goMaxProcs` anywhere, GOMAXPROCS derives from the overridden CPU request (e.g. 2500m → 3)
- an override below 4 GiB of memory per CPU fails rendering with the existing validation message

Added a `ci/` values file exercising one inheriting and one overriding deployment so `ct` lints and installs the new path, documented the override in `values.yaml` and the README, and bumped the chart version to 1.0.75 (rebased over the v827 release, which took 1.0.74).
